### PR TITLE
Add Hangzhou Telecom NXDOMAIN

### DIFF
--- a/bogus-nxdomain.china.conf
+++ b/bogus-nxdomain.china.conf
@@ -61,3 +61,7 @@ bogus-nxdomain=61.139.8.101
 bogus-nxdomain=61.139.8.102
 bogus-nxdomain=61.139.8.103
 bogus-nxdomain=61.139.8.104
+
+#Hangzhou Telecom
+bogus-nxdomain=::
+bogus-nxdomain=60.191.124.236


### PR DESCRIPTION
杭州电信为了保证劫持效果，居然会先返回一个`::`……没错就是两个冒号！艹
![2014-01-05_104231](https://f.cloud.github.com/assets/406779/1845926/0bd31918-75b3-11e3-8649-43501f64a9f7.png)
