### PR TITLE
添加 sfcdn.org

### DIFF
--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -1072,6 +1072,7 @@ server=/secoo.com/114.114.114.114
 server=/secooimg.com/114.114.114.114
 server=/seowhy.com/114.114.114.114
 server=/sf-express.com/114.114.114.114
+server=/sfcdn.org/114.114.114.114
 server=/sg560.com/114.114.114.114
 server=/shangdu.com/114.114.114.114
 server=/shejis.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -180,6 +180,7 @@ server=/778669.com/114.114.114.114
 server=/7c.com/114.114.114.114
 server=/7cen.com/114.114.114.114
 server=/7k7k.com/114.114.114.114
+server=/7po.com/114.114.114.114
 server=/800cdn.com/114.114.114.114
 server=/800hr.com/114.114.114.114
 server=/8090.pk/114.114.114.114


### PR DESCRIPTION
img.sfcdn.org.		30	IN	CNAME	xdtv-img.b0.upaiyun.com.
xdtv-img.b0.upaiyun.com. 1528	IN	CNAME	cun.b9.aicdn.com.

apps.sfcdn.org.		30	IN	CNAME	apps.sfcdn.org.w.alikunlun.com.
apps.sfcdn.org.w.alikunlun.com.	74 IN	A	119.188.96.110
apps.sfcdn.org.w.alikunlun.com.	74 IN	A	119.188.96.109

沙发管家 shafa.com 在用