### PR TITLE
添加 doubanio.com

### DIFF
--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -508,6 +508,7 @@ server=/donews.com/114.114.114.114
 server=/dospy.com/114.114.114.114
 server=/douban.com/114.114.114.114
 server=/douban.fm/114.114.114.114
+server=/doubanio.com/114.114.114.114
 server=/douyu.tv/114.114.114.114
 server=/douyutv.com/114.114.114.114
 server=/download.windowsupdate.com/114.114.114.114


### PR DESCRIPTION
s.doubanio.com.		85345	IN	CNAME	s.doubanio.com.wscdns.com.
s.doubanio.com.wscdns.com. 153	IN	CNAME	1st.dtwscachev105.glb0.lxdns.com.
1st.dtwscachev105.glb0.lxdns.com. 94 IN	A	61.140.14.84

豆瓣