### PR TITLE
accelerated domains: Google fonts

### DIFF
--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -621,6 +621,7 @@ server=/fenzhi.com/114.114.114.114
 server=/ffdy.cc/114.114.114.114
 server=/fhldns.com/114.114.114.114
 server=/fobshanghai.com/114.114.114.114
+server=/fonts.googleapis.com/114.114.114.114
 server=/fpwap.com/114.114.114.114
 server=/fsfund.com/114.114.114.114
 server=/fspcdn.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -622,6 +622,7 @@ server=/ffdy.cc/114.114.114.114
 server=/fhldns.com/114.114.114.114
 server=/fobshanghai.com/114.114.114.114
 server=/fonts.googleapis.com/114.114.114.114
+server=/fonts.gstatic.com/114.114.114.114
 server=/fpwap.com/114.114.114.114
 server=/fsfund.com/114.114.114.114
 server=/fspcdn.com/114.114.114.114


### PR DESCRIPTION
`fonts.googleapis.com` and `fonts.gstatic.com` are now resolves to Google Beijing and not being blocked anymore.