### PR TITLE
添加 iwencai.com

### DIFF
--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -735,6 +735,7 @@ server=/itiexue.net/114.114.114.114
 server=/itouzi.com/114.114.114.114
 server=/itunes-apple.com.akadns.net/114.114.114.114
 server=/iweek.ly/114.114.114.114
+server=/iwencai.com/114.114.114.114
 server=/iwpai.com/114.114.114.114
 server=/iyaya.com/114.114.114.114
 server=/iyaya.info/114.114.114.114


### PR DESCRIPTION
同花顺的网站，国内用了 CDN 的。

;; QUESTION SECTION:
;www.iwencai.com.		IN	A

;; ANSWER SECTION:
www.iwencai.com.	49	IN	CNAME	cachenwv.iwencai.com.
cachenwv.iwencai.com.	7778	IN	A	61.136.59.130
cachenwv.iwencai.com.	7778	IN	A	124.160.148.172