### PR TITLE
Add wooyun.org

### DIFF
--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -1310,6 +1310,7 @@ server=/winshang.com/114.114.114.114
 server=/winvvv.com/114.114.114.114
 server=/wkimg.com/114.114.114.114
 server=/woniu.com/114.114.114.114
+server=/wooyun.org/114.114.114.114
 server=/woqidai.com/114.114.114.114
 server=/wosign.com/114.114.114.114
 server=/woziben.com/114.114.114.114


### PR DESCRIPTION
国外：
wooyun.org.		10	IN	CNAME	wooyun.org.cname.yunjiasu-cdn.net.
wooyun.org.cname.yunjiasu-cdn.net. 300 IN A	162.159.209.53
wooyun.org.cname.yunjiasu-cdn.net. 300 IN A	162.159.208.53

国内：
www.wooyun.org.		30	IN	CNAME	38e19297bd1e3f34.cdn.fhldns.com.
38e19297bd1e3f34.cdn.fhldns.com. 30 IN	A	61.182.137.3