### PR TITLE
add f3322.net

### DIFF
--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -2491,6 +2491,7 @@ server=/ezdnscenter.com/114.114.114.114
 server=/eznowdns.net/114.114.114.114
 server=/ezubo.com/114.114.114.114
 server=/f2e.im/114.114.114.114
+server=/f3322.net/114.114.114.114
 server=/f3322.org/114.114.114.114
 server=/f70123.com/114.114.114.114
 server=/fa71.com/114.114.114.114


### PR DESCRIPTION
属于3322旗下，ns服务器为ns1.3322.net/ns2.3322.net，均在国内