### PR TITLE
added yufmcdn.com

### DIFF
--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -7483,3 +7483,4 @@ server=/zzlmg-win.com/114.114.114.114
 server=/zzndns.com/114.114.114.114
 server=/zzwljc.com/114.114.114.114
 server=/zzyjedu.com/114.114.114.114
+server=/yufmcdn.com/114.114.114.114


### PR DESCRIPTION
章鱼FM使用Amazon的服务器，
>music.yufmcdn.com
>images.yufmcdn.com

国内外解析的结果不相同

国外（使用日本的VPN） dig music.yufmcdn.com @8.8.8.8
>;; QUESTION SECTION:
>;music.yufmcdn.com.		IN	A

>;; ANSWER SECTION:
>music.yufmcdn.com.	3150	IN	CNAME	7pumt7.v2.dl.z0.glb.qiniudns.com.
>7pumt7.v2.dl.z0.glb.qiniudns.com. 150 IN CNAME	music.yufmcdn.com.wscdns.com.
>music.yufmcdn.com.wscdns.com. 150 IN	CNAME	oversea.dlmix.speedcdns.com.
>oversea.dlmix.speedcdns.com. 150 IN	A	61.120.154.174

国内（使用中国电信网络）dig music.yufmcdn.com @114.114.114.114
>;; QUESTION SECTION:
>;music.yufmcdn.com.		IN	A

>;; ANSWER SECTION:
>music.yufmcdn.com.	1260	IN	CNAME	7pumt7.v2.dl.z0.glb.qiniudns.com.
>7pumt7.v2.dl.z0.glb.qiniudns.com. 30 IN	CNAME	music.yufmcdn.com.wscdns.com.
>music.yufmcdn.com.wscdns.com. 30 IN	CNAME	netcenter.dlmix.ourdvs.com.
>netcenter.dlmix.ourdvs.com. 30	IN	A	58.222.18.117
>netcenter.dlmix.ourdvs.com. 30	IN	A	218.92.227.111
>netcenter.dlmix.ourdvs.com. 30	IN	A	218.92.221.27