### PR TITLE
add UBNT CDN

### DIFF
--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -11586,6 +11586,7 @@ server=/dksrcw.com/114.114.114.114
 server=/dktime.org/114.114.114.114
 server=/dky.cc/114.114.114.114
 server=/dl-mec.com/114.114.114.114
+server=/dl-origin.ubnt.com/114.114.114.114
 server=/dl.delivery.mp.microsoft.com/114.114.114.114
 #server=/dl.google.com/114.114.114.114
 server=/dl1234.com/114.114.114.114


### PR DESCRIPTION
UBNT 的 apt-get 源增加了国内 CDN

```
$ dig dl-origin.ubnt.com @114.114.114.114

; <<>> DiG 9.8.3-P1 <<>> dl-origin.ubnt.com @114.114.114.114
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 22932
;; flags: qr rd ra; QUERY: 1, ANSWER: 11, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;dl-origin.ubnt.com.		IN	A

;; ANSWER SECTION:
dl-origin.ubnt.com.	300	IN	CNAME	dl-origin.ubnt.com.wsdvs.com.
dl-origin.ubnt.com.wsdvs.com. 600 IN	CNAME	1st.ecoma.ourwebpic.com.
1st.ecoma.ourwebpic.com. 41	IN	A	218.59.186.76
1st.ecoma.ourwebpic.com. 41	IN	A	60.211.208.30
1st.ecoma.ourwebpic.com. 41	IN	A	60.211.208.31
1st.ecoma.ourwebpic.com. 41	IN	A	60.211.208.32
1st.ecoma.ourwebpic.com. 41	IN	A	60.211.208.33
1st.ecoma.ourwebpic.com. 41	IN	A	119.184.176.196
1st.ecoma.ourwebpic.com. 41	IN	A	119.184.176.197
1st.ecoma.ourwebpic.com. 41	IN	A	119.184.176.198
1st.ecoma.ourwebpic.com. 41	IN	A	119.184.176.199

;; Query time: 206 msec
;; SERVER: 114.114.114.114#53(114.114.114.114)
;; WHEN: Thu Jun  2 16:31:05 2016
;; MSG SIZE  rcvd: 253
```