### PR TITLE
Add Nvidia

### DIFF
--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -23945,6 +23945,7 @@ server=/nuxue.com/114.114.114.114
 server=/nv91.us/114.114.114.114
 server=/nvailady.com/114.114.114.114
 server=/nvhaiwu.com/114.114.114.114
+server=/nvidia.com/114.114.114.114
 server=/nvliren.com/114.114.114.114
 server=/nvloo.com/114.114.114.114
 server=/nvsay.com/114.114.114.114


### PR DESCRIPTION
添加nvidia的原因是
1 nvidia在中国并没有被墙记录（我没搜到，欢迎补充）
2 GeForce Exp...... 软件中，如果不添加nvidia全站，会导致更新缓慢（自己测试过）
