### PR TITLE
增加 MIUI Portal Server.

### DIFF
--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -10820,6 +10820,7 @@ server=/comsenz.com/114.114.114.114
 server=/comseoer.com/114.114.114.114
 server=/comvps.com/114.114.114.114
 server=/con.mn/114.114.114.114
+server=/connect.rom.miui.com/114.114.114.114
 server=/conaida.com/114.114.114.114
 server=/conans.cc/114.114.114.114
 server=/configure.ap.dell.com/114.114.114.114


### PR DESCRIPTION
https://connect.rom.miui.com
解决国内无法访问 Google Portal Server 导致 Wi-Fi 图标出现感叹号的问题（7.0 之后需 HTTPS）