### PR TITLE
add giuem.com

### DIFF
--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -18381,6 +18381,7 @@ server=/gitshu.com/114.114.114.114
 server=/gitv.tv/114.114.114.114
 server=/gityuan.com/114.114.114.114
 server=/gitzx.com/114.114.114.114
+server=/giuem.com/114.114.114.114
 server=/givezhufu.com/114.114.114.114
 server=/gizwits.com/114.114.114.114
 server=/gj515.com/114.114.114.114


### PR DESCRIPTION
1. The domain's NS server (**CloudXNS**) is located in China mainland. 
``` shell
$ dig giuem.com NS +short
lv3ns1.ffdns.net.
lv3ns4.ffdns.net.
lv3ns3.ffdns.net.
lv3ns2.ffdns.net.
```
2. The domain will resolve to an IP located in China mainland when using a Chinese DNS server, but not always do when using a foreign DNS server
``` shell
# Shanghai, China
$ dig @114.114.114.114 ga.giuem.com A +short
115.159.188.148

# Cloudflare
$ dig @1.1.1.1 ga.giuem.com A +short
104.16.24.100
104.16.25.100
```