### PR TITLE
Add "etiantian.net" to accelerated-domains

### DIFF
--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -24735,6 +24735,7 @@ server=/ethern.me/114.114.114.114
 server=/ethfans.org/114.114.114.114
 server=/etiantian.com/114.114.114.114
 server=/etiantian.info/114.114.114.114
+server=/etiantian.net/114.114.114.114
 server=/etiantian.org/114.114.114.114
 server=/etiaoliao.com/114.114.114.114
 server=/etimeusa.com/114.114.114.114


### PR DESCRIPTION
`school.etiantian.com`, which is a live-stream class platform, uses a cdn `cdn1.school.etiantian.net`.