### PR TITLE
accelerated-domains: add fenliu.net

### DIFF
--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -26125,6 +26125,7 @@ server=/fenlei168.com/114.114.114.114
 server=/fenlei265.com/114.114.114.114
 server=/fenleidao.com/114.114.114.114
 server=/fenleitong.com/114.114.114.114
+server=/fenliu.net/114.114.114.114
 server=/fenmr.com/114.114.114.114
 server=/fennessy.hk/114.114.114.114
 server=/fenq.com/114.114.114.114


### PR DESCRIPTION
fenliu.net is a domain used by 12306 Bypass software
for sliding captcha automation