### PR TITLE
accelerated-domains: add gw.craft.moe

### DIFF
--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -24793,6 +24793,7 @@ server=/gvi-tech.com/114.114.114.114
 server=/gvlocalization.com/114.114.114.114
 server=/gvofl.com/114.114.114.114
 server=/gw-ec.com/114.114.114.114
+server=/gw.craft.moe/114.114.114.114
 server=/gw2sc.com/114.114.114.114
 server=/gw66.vip/114.114.114.114
 server=/gw8888.com/114.114.114.114


### PR DESCRIPTION
The gateway of craft.moe has been changed from gateway.craft.moe to gw.craft.moe.

```shellsession
$ dig gw.nyaacat.com CNAME @114.114.114.114 +short
bj.ep.nyaacat.com.
$ dig gw.nyaacat.com CNAME @1.1.1.1 +short
hk.ep.nyaacat.com.
```