### PR TITLE
Update apple.china.conf

### DIFF
--- a/apple.china.conf
+++ b/apple.china.conf
@@ -129,6 +129,7 @@ server=/updates-http.cdn-apple.com/114.114.114.114
 server=/updates.cdn-apple.com/114.114.114.114
 server=/valid.apple.com/114.114.114.114
 server=/valid.origin-apple.com.akadns.net/114.114.114.114
+server=/weather-data.apple.com.akadns.net/114.114.114.114
 server=/weather-data.apple.com/114.114.114.114
 server=/www.apple.com.edgekey.net.globalredir.akadns.net/114.114.114.114
 server=/www.apple.com.edgekey.net/114.114.114.114


### PR DESCRIPTION
Occasionlly, `weather-data.apple.com.akadns.net` is directly queried.
Same issue: https://github.com/felixonmars/dnsmasq-china-list/issues/402.