### PR TITLE
generate hash by ci

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,3 +10,10 @@ jobs:
         bundler-cache: true
     - name: Run tests
       run: bundle exec sus
+    - name: gen hash
+      run: |
+        echo "hash=$(sha256sum accelerated-domains.china.conf)" >> $GITHUB_ENV
+    - uses: actions/upload-artifact@v3
+      with:
+        name: ${{env.hash}}
+        path: /dev/null


### PR DESCRIPTION
client can use hash to check update or corruption.
how to get hash
```shell
curl https://api.github.com/repos/OWNER/dnsmasq-china-list/actions/runs/$(curl https://api.github.com/repos/OWNER/dnsmasq-china-list/actions/runs | jq .workflow_runs[0].id)/artifacts |jq -r .artifacts[0].name
```