### PR TITLE
accelerated-domains: add zanao.com

### DIFF
--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -61450,6 +61450,7 @@ server=/zampdmp.com/114.114.114.114
 server=/zampdsp.com/114.114.114.114
 server=/zamplink.net/114.114.114.114
 server=/zamplus.com/114.114.114.114
+server=/zanao.com/114.114.114.114
 server=/zanba.com/114.114.114.114
 server=/zanbai.com/114.114.114.114
 server=/zangaifamily.com/114.114.114.114


### PR DESCRIPTION
<img width="243" alt="image" src="https://github.com/felixonmars/dnsmasq-china-list/assets/31185624/19f992bf-84b0-48c7-8781-112f25317029">

A campus community used in some universities in mainland China. Using overseas DNS may cause access issues.