### PR TITLE
accelerated-domains: add cskaoyan.com

### DIFF
--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -16401,6 +16401,7 @@ server=/csjcs.com/114.114.114.114
 server=/csjplatform.com/114.114.114.114
 server=/csjwang.com/114.114.114.114
 server=/csjyzq.com/114.114.114.114
+server=/cskaoyan.com/114.114.114.114
 server=/cskefu.com/114.114.114.114
 server=/cskule.com/114.114.114.114
 server=/cslfans.com/114.114.114.114


### PR DESCRIPTION
cskaoyan.com 在大陆以外的解析结果为 127.0.0.1
```
~$ dig +subnet=1.2.4.8/24 cskaoyan.com @223.5.5.5 +short
cskaoyan.com.cname853.yjs-cdn.com.
125.39.239.79
~$ dig +subnet=1.1.1.1/24 cskaoyan.com @223.5.5.5 +short
127.0.0.1
```