### PR TITLE
Update google.china.conf

### DIFF
--- a/google.china.conf
+++ b/google.china.conf
@@ -41,6 +41,7 @@ server=/distribution.qcpp1.net/114.114.114.114
 server=/distribution.qpdp1.net/114.114.114.114
 server=/dl.google.com/114.114.114.114
 server=/dl.l.google.com/114.114.114.114
+server=/doubleclick-cn.net/114.114.114.114
 server=/download.mlcc.google.com/114.114.114.114
 server=/download.qatp1.net/114.114.114.114
 server=/download.qcpp1.net/114.114.114.114


### PR DESCRIPTION
Remove `doubleclick.net`  as it requires proxy to access.
 Remove `doubleclick-cn.net`  due to HTTP 404 Not Found