### PR TITLE
Update google.china.conf

### DIFF
--- a/google.china.conf
+++ b/google.china.conf
@@ -190,3 +190,6 @@ server=/sup.l.google.com/114.114.114.114
 server=/uberproxy-with-cn.l.google.com/114.114.114.114
 server=/uberproxy-with-cn4.l.google.com/114.114.114.114
 server=/uberproxy-with-cn6.l.google.com/114.114.114.114
+
+# Other corp related domain
+server=/qiao-cn.com/114.114.114.114


### PR DESCRIPTION
qiao-cn.com is used for Google China corp related usage and hosted on Alicloud DNS.