### PR TITLE
Add macOS homebrew support for install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Automatic Installation (recommended)
 
 1. Fetch the installer from github (or a mirror): `wget https://raw.githubusercontent.com/felixonmars/dnsmasq-china-list/master/install.sh`
 2. (Optional) Edit it to use your favorite DNS server and/or another mirror to download the list.
-3. Run it as root: `sudo ./install.sh`
+3. Run it as root: `sudo ./install.sh`, or if you use Homebrew on macOS: `sudo bash ./install.sh /opt/homebrew/etc/dnsmasq.d`
 
 You can save the installer and run it again to update the list regularly.
 

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,7 @@
 set -e
 
 WORKDIR="$(mktemp -d)"
+CONFDIR=${1:-"/etc/dnsmasq.d"}
 SERVERS=(114.114.114.114 114.114.115.115 223.5.5.5 119.29.29.29)
 # Others: 223.6.6.6 119.28.28.28
 # Not using best possible CDN pop: 1.2.4.8 210.2.4.8
@@ -22,20 +23,20 @@ git clone --depth=1 https://gitee.com/felixonmars/dnsmasq-china-list.git "$WORKD
 
 echo "Removing old configurations..."
 for _conf in "${CONF_WITH_SERVERS[@]}" "${CONF_SIMPLE[@]}"; do
-  rm -f /etc/dnsmasq.d/"$_conf"*.conf
+  rm -f "$CONFDIR"/"$_conf"*.conf
 done
 
 echo "Installing new configurations..."
 for _conf in "${CONF_SIMPLE[@]}"; do
-  cp "$WORKDIR/$_conf.conf" "/etc/dnsmasq.d/$_conf.conf"
+  cp "$WORKDIR/$_conf.conf" "$CONFDIR/$_conf.conf"
 done
 
 for _server in "${SERVERS[@]}"; do
   for _conf in "${CONF_WITH_SERVERS[@]}"; do
-    cp "$WORKDIR/$_conf.conf" "/etc/dnsmasq.d/$_conf.$_server.conf"
+    cp "$WORKDIR/$_conf.conf" "$CONFDIR/$_conf.$_server.conf"
   done
 
-  sed -i "s|^\(server.*\)/[^/]*$|\1/$_server|" /etc/dnsmasq.d/*."$_server".conf
+  sed -i "" "s|^\(server.*\)/[^/]*$|\1/$_server|" $CONFDIR/*."$_server".conf
 done
 
 echo "Restarting dnsmasq service..."
@@ -47,6 +48,8 @@ elif hash rc-service 2>/dev/null; then
   rc-service dnsmasq restart
 elif hash busybox 2>/dev/null && [[ -d "/etc/init.d" ]]; then
   /etc/init.d/dnsmasq restart
+elif hash brew 2>/dev/null; then
+  brew services restart dnsmasq
 else
   echo "Now please restart dnsmasq since I don't know how to do it."
 fi


### PR DESCRIPTION
add macOS home-brew support for install.sh
`sudo bash ./install.sh /opt/homebrew/etc/dnsmasq.d`