### PR TITLE
[Add] jianying.com

### DIFF
--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -34511,6 +34511,7 @@ server=/jianweitv.com/114.114.114.114
 server=/jianwenapp.com/114.114.114.114
 server=/jianxinyun.com/114.114.114.114
 server=/jianyanjia.com/114.114.114.114
+server=/jianying.com/114.114.114.114
 server=/jianyu360.com/114.114.114.114
 server=/jianyujiasu.com/114.114.114.114
 server=/jianyuweb.com/114.114.114.114


### PR DESCRIPTION
`jianying.com` has China CDN service, 
similarly subdomains `dreamina.jianying.com` etc.