### PR TITLE
Update ns-whitelist.txt

### DIFF
--- a/ns-blacklist.txt
+++ b/ns-blacklist.txt
@@ -25,6 +25,7 @@
 .your-server.de
 .yandex.net
 .techsmith.com
+.ns1global.org
 .nsone.net
 .fastly.net
 .hosteurope.de


### PR DESCRIPTION
提交了一些有中国节点的 NS 服务器，这些 NS 服务器做了 geodns，国内节点由阿里 dns 提供。
不确定是不是要写在 ns-whitelist.txt 里边？

```
NS dimitris.ns.cloudcflare.com verified true for domain damixs.biz
NS dns1.g01.ns1global.org verified true for domain dandongrq.com
NS d.ttdns.net verified true for domain projectoms.com
```

`*.ns.cloudcflare.com`  (这个李鬼域名可能是 GoDaddy 的) : 
```
$ dig -t NS damixs.biz +short 
dimitris.ns.cloudcflare.com.
vip8.alidns.com.
vip7.alidns.com.
brianna.ns.cloudcflare.com.
$ dig +subnet=1.2.4.0/24 dimitris.ns.cloudcflare.com @8.8.8.8 +short # 中国节点
121.40.6.168
140.205.1.14
47.108.36.168
39.103.26.217
$ dig +subnet=1.1.1.0/24 dimitris.ns.cloudcflare.com @8.8.8.8 +short # 海外节点
170.33.80.15
8.212.93.8
```

`dns1~4.g01.ns1global.org`:
```
$ dig -t NS dandongrq.com +short
dns3.g01.ns1global.org.
dns2.g01.ns1global.org.
dns1.g01.ns1global.org.
dns4.g01.ns1global.org.
$ dig +subnet=1.2.4.0/24 dns1.g01.ns1global.org. @8.8.8.8 +short # 中国节点
118.190.149.197
$ dig +subnet=1.1.1.0/24 dimitris.ns.cloudcflare.com @8.8.8.8 +short # 海外节点
8.212.93.8
170.33.80.15
```


`a~j.ttdns.net`:
```
$ dig -t NS projectoms.com +short
dns29.hichina.com.
c.ttdns.net.
d.ttdns.net.
dns30.hichina.com.
$ dig +subnet=1.2.4.0/24 d.ttdns.net. @8.8.8.8 +short # 中国节点
118.190.149.197
$ dig +subnet=1.1.1.0/24 d.ttdns.net. @8.8.8.8 +short # 海外节点
205.251.193.248
205.251.199.210
```

