### PR TITLE
accelerated-domains: remove iflow.work

### DIFF
--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -39046,7 +39046,6 @@ server=/ifireflygame.com/114.114.114.114
 server=/ifiretech.com/114.114.114.114
 server=/ifitbox.com/114.114.114.114
 server=/ifjing.com/114.114.114.114
-server=/iflow.work/114.114.114.114
 server=/iflygse.com/114.114.114.114
 server=/iflyhealth.com/114.114.114.114
 server=/iflying.com/114.114.114.114


### PR DESCRIPTION
```
$ drill iflow.work @223.5.5.5
;; ->>HEADER<<- opcode: QUERY, rcode: NOERROR, id: 20426
;; flags: qr rd ra ; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 0 
;; QUESTION SECTION:
;; iflow.work.	IN	A

;; ANSWER SECTION:
iflow.work.	600	IN	A	141.101.114.160
iflow.work.	600	IN	A	172.67.140.199

;; AUTHORITY SECTION:

;; ADDITIONAL SECTION:

;; Query time: 98 msec
;; SERVER: 223.5.5.5
;; WHEN: Fri Aug  9 09:14:34 2024
;; MSG SIZE  rcvd: 60

Ip:141.101.114.160
City:San Francisco
Region:California
Country:US
Loc:37.7621,-122.3971
Org:AS13335 Cloudflare, Inc.
Postal:94107
Timezone:America/Los_Angeles

Ip:172.67.140.199
City:San Francisco
Region:California
Country:US
Loc:37.7621,-122.3971
Org:AS13335 Cloudflare, Inc.
Postal:94107
Timezone:America/Los_Angeles
```

Source from this FAQ of site: https://www.yuque.com/null_42/steam/tfe59eeg6m1b3wki

> 5. 为什么网站访问这么慢 / 网站打不开？
> 自 2023 年 5 月起，挂刀行情站开始受到不定期的、未知来源的 [DDoS 攻击](https://baike.baidu.com/item/%E5%88%86%E5%B8%83%E5%BC%8F%E6%8B%92%E7%BB%9D%E6%9C%8D%E5%8A%A1%E6%94%BB%E5%87%BB)，导致站点服务器多次被运营商停用。由于无法负担起高额的防御成本，我们通过接入免费的 Cloudflare CDN 来实现 DDoS 防护。但是，Cloudflare 仅提供境外 CDN 节点，这使得境内网络环境下访问站点时，可能会出现延迟、丢包等现象。
我们在持续优化境内网络访问站点的便利程度。根据测试 (2024/06/12)，境内 95% 以上的地区&运营商应当都可以正常访问挂刀行情站。然而，如果仍然出现网站无法打开的情况，可以考虑更换网络环境，或临时使用我们的微信小程序“挂刀助手”。
如果（极少数情况下）打开后显示 XXX Error，那就是服务器宕机了，在修了在修了 ...