### PR TITLE
add peiyinxiu.com

### DIFF
--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -57701,6 +57701,7 @@ server=/peiyake.com/114.114.114.114
 server=/peiyin.net/114.114.114.114
 server=/peiyinge.com/114.114.114.114
 server=/peiyinshenqi.club/114.114.114.114
+server=/peiyinxiu.com/114.114.114.114
 server=/peiyou.com/114.114.114.114
 server=/peiyouwang.com/114.114.114.114
 server=/peizi.com/114.114.114.114


### PR DESCRIPTION
The subdomain **img7.peiyinxiu.com** will resolve to an IP located in US when using the Cloudflare DNS and the Google DNS.