### PR TITLE
Update accelerated-domains.china.conf

### DIFF
--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -10698,6 +10698,7 @@ server=/alpacabro.com/114.114.114.114
 server=/alpha-browser.com/114.114.114.114
 server=/alpha-star.org/114.114.114.114
 server=/alphabole.com/114.114.114.114
+server=/alphassl.com/114.114.114.114
 server=/alphay.com/114.114.114.114
 server=/alrailpha.com/114.114.114.114
 server=/alrightzd.com/114.114.114.114


### PR DESCRIPTION
    static.tripcdn.com
    secure.globalsign.com
    mallpage.shanghaimengtaishangcheng.com
    kmio.ins.citic
    api.yingkefuli.com
    www.alphassl.com
@felixonmars Only third-level domains are resolved for these domains. Should the file include third-level domains or second-level domains?