### PR TITLE
Update accelerated-domains.china.conf

### DIFF
--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -65545,7 +65545,6 @@ server=/q2d.com/114.114.114.114
 server=/q2usj.icu/114.114.114.114
 server=/q2zy.com/114.114.114.114
 server=/q3060.com/114.114.114.114
-server=/q4ee.top/114.114.114.114
 server=/q5.com/114.114.114.114
 server=/q6haqi.com/114.114.114.114
 server=/q6q.cc/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -69000,7 +69000,6 @@ server=/rootop.org/114.114.114.114
 server=/rootopen.com/114.114.114.114
 server=/rootzhushou.com/114.114.114.114
 server=/roouoo.com/114.114.114.114
-server=/roozen.top/114.114.114.114
 server=/ropefitting.com/114.114.114.114
 server=/ropinsite.com/114.114.114.114
 server=/roqairs.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -65566,7 +65566,6 @@ server=/qapi.cc/114.114.114.114
 server=/qaqgame.com/114.114.114.114
 server=/qaros.com/114.114.114.114
 server=/qast.com/114.114.114.114
-server=/qattdh6.top/114.114.114.114
 server=/qaxanyu.com/114.114.114.114
 server=/qaxanyuv6.com/114.114.114.114
 server=/qaxcloudwaf.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -65566,7 +65566,6 @@ server=/qapi.cc/114.114.114.114
 server=/qaqgame.com/114.114.114.114
 server=/qaros.com/114.114.114.114
 server=/qast.com/114.114.114.114
-server=/qattdh.top/114.114.114.114
 server=/qattdh6.top/114.114.114.114
 server=/qaxanyu.com/114.114.114.114
 server=/qaxanyuv6.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -84496,7 +84496,6 @@ server=/wkdty.com/114.114.114.114
 server=/wkepu.com/114.114.114.114
 server=/wkhub.com/114.114.114.114
 server=/wkimg.com/114.114.114.114
-server=/wkjava.top/114.114.114.114
 server=/wkjhd.com/114.114.114.114
 server=/wkkshu.com/114.114.114.114
 server=/wklken.me/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -80347,7 +80347,6 @@ server=/ugshare-img.com/114.114.114.114
 server=/ugslb.com/114.114.114.114
 server=/ugslb.info/114.114.114.114
 server=/ugslb.net/114.114.114.114
-server=/ugslb.top/114.114.114.114
 server=/ugslb2.net/114.114.114.114
 server=/ugsnx.com/114.114.114.114
 server=/ugsvscw.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -67190,7 +67190,6 @@ server=/qtkj.love/114.114.114.114
 server=/qtlcdn.com/114.114.114.114
 server=/qtlcdn.net/114.114.114.114
 server=/qtlcdn360.info/114.114.114.114
-server=/qtlcdn360.top/114.114.114.114
 server=/qtlcdn360.xin/114.114.114.114
 server=/qtlcdn360.xyz/114.114.114.114
 server=/qtlcdncn.info/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -65898,7 +65898,6 @@ server=/qh6bc.com/114.114.114.114
 server=/qh9y.com/114.114.114.114
 server=/qhaif.com/114.114.114.114
 server=/qhangyun.com/114.114.114.114
-server=/qhapp.top/114.114.114.114
 server=/qhass.org/114.114.114.114
 server=/qhbtv.com/114.114.114.114
 server=/qhcby.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -65005,7 +65005,6 @@ server=/pphimalayanrt.com/114.114.114.114
 server=/pphqq.com/114.114.114.114
 server=/ppio.cloud/114.114.114.114
 server=/ppio.work/114.114.114.114
-server=/ppio12181ios.top/114.114.114.114
 server=/ppio12191ios.top/114.114.114.114
 server=/ppio12200ios.top/114.114.114.114
 server=/ppj.io/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -81341,7 +81341,6 @@ server=/vendue.vip/114.114.114.114
 server=/venlvcloud.com/114.114.114.114
 server=/ventoy.net/114.114.114.114
 server=/venucia.com/114.114.114.114
-server=/venum.top/114.114.114.114
 server=/venuscn.com/114.114.114.114
 server=/venusgroup.asia/114.114.114.114
 server=/venusong.site/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -97388,7 +97388,6 @@ server=/zlfind.com/114.114.114.114
 server=/zlfshop.com/114.114.114.114
 server=/zlfzyj.com/114.114.114.114
 server=/zlg.com/114.114.114.114
-server=/zlgame.top/114.114.114.114
 server=/zlgcgl.com/114.114.114.114
 server=/zlgmcu.com/114.114.114.114
 server=/zlgpy.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -86006,7 +86006,6 @@ server=/x78j7hk.com/114.114.114.114
 server=/x7game.com/114.114.114.114
 server=/x7sy.com/114.114.114.114
 server=/x7z.cc/114.114.114.114
-server=/x800.top/114.114.114.114
 server=/x81zw.co/114.114.114.114
 server=/x81zw.com/114.114.114.114
 server=/x81zw2.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -68103,7 +68103,6 @@ server=/raineggplant.com/114.114.114.114
 server=/raingray.com/114.114.114.114
 server=/rainhj.com/114.114.114.114
 server=/rainhz.com/114.114.114.114
-server=/raining.top/114.114.114.114
 server=/rainlain.com/114.114.114.114
 server=/rainso.com/114.114.114.114
 server=/rainwe.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -91379,7 +91379,6 @@ server=/yilule.com/114.114.114.114
 server=/yiluup.com/114.114.114.114
 server=/yiluzouhao.com/114.114.114.114
 server=/yilvcheng.com/114.114.114.114
-server=/yim3eyv5.top/114.114.114.114
 server=/yimakk.com/114.114.114.114
 server=/yimao.net/114.114.114.114
 server=/yimaoip.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -90806,7 +90806,6 @@ server=/yeoner.com/114.114.114.114
 server=/yephy.com/114.114.114.114
 server=/yeree.com/114.114.114.114
 server=/yergoo.com/114.114.114.114
-server=/yerhfnytky.top/114.114.114.114
 server=/yeryt111.fun/114.114.114.114
 server=/yes-chinese.com/114.114.114.114
 server=/yes115.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -87326,7 +87326,6 @@ server=/xiaozuan8.com/114.114.114.114
 server=/xiaozuanbike.com/114.114.114.114
 server=/xiaozujian.com/114.114.114.114
 server=/xiaozuowen.net/114.114.114.114
-server=/xiaozusun.top/114.114.114.114
 server=/xiapac.com/114.114.114.114
 server=/xiapilu.com/114.114.114.114
 server=/xiaping11.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -88934,7 +88934,6 @@ server=/xpdf.net/114.114.114.114
 server=/xpeae.com/114.114.114.114
 server=/xpeng.link/114.114.114.114
 server=/xpfengshui.com/114.114.114.114
-server=/xpicw.top/114.114.114.114
 server=/xpj0066.com/114.114.114.114
 server=/xpj16.net/114.114.114.114
 server=/xpj6789.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -62407,7 +62407,6 @@ server=/oafocus.net/114.114.114.114
 server=/oahelp.com/114.114.114.114
 server=/oahelp.net/114.114.114.114
 server=/oaimai.com/114.114.114.114
-server=/oaiqksi.top/114.114.114.114
 server=/oait360.com/114.114.114.114
 server=/oajdsr.xyz/114.114.114.114
 server=/oaklandjs.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -85359,7 +85359,6 @@ server=/wuhujianshe.com/114.114.114.114
 server=/wuhukj.fun/114.114.114.114
 server=/wuhusanlian.com/114.114.114.114
 server=/wui5.com/114.114.114.114
-server=/wuisaq.top/114.114.114.114
 server=/wuji-edu.com/114.114.114.114
 server=/wuji.com/114.114.114.114
 server=/wujia800.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -62968,7 +62968,6 @@ server=/openinstall.com/114.114.114.114
 server=/openinstall.io/114.114.114.114
 server=/openintelliedge.tech/114.114.114.114
 server=/openke.net/114.114.114.114
-server=/openkylin.top/114.114.114.114
 server=/openlanguage.com/114.114.114.114
 server=/openlayers.vip/114.114.114.114
 server=/openlink.cc/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -65005,7 +65005,6 @@ server=/pphimalayanrt.com/114.114.114.114
 server=/pphqq.com/114.114.114.114
 server=/ppio.cloud/114.114.114.114
 server=/ppio.work/114.114.114.114
-server=/ppio12191ios.top/114.114.114.114
 server=/ppio12200ios.top/114.114.114.114
 server=/ppj.io/114.114.114.114
 server=/ppjtc.net/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -84472,7 +84472,6 @@ server=/wjsw.com/114.114.114.114
 server=/wjtzyg.com/114.114.114.114
 server=/wjwuqiang.com/114.114.114.114
 server=/wjx.com/114.114.114.114
-server=/wjx.top/114.114.114.114
 server=/wjxcdn.com/114.114.114.114
 server=/wjy01.com/114.114.114.114
 server=/wjyanghu.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -87727,7 +87727,6 @@ server=/xingzai.pub/114.114.114.114
 server=/xingzhang.com/114.114.114.114
 server=/xingzhige.com/114.114.114.114
 server=/xingzhilan.com/114.114.114.114
-server=/xingzhu.top/114.114.114.114
 server=/xingzi-vision.com/114.114.114.114
 server=/xingzou.art/114.114.114.114
 server=/xingzoushu.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -68902,7 +68902,6 @@ server=/roguelitegames.com/114.114.114.114
 server=/rohm-chip.com/114.114.114.114
 server=/rohs-china.com/114.114.114.114
 server=/roidmi.com/114.114.114.114
-server=/roio.top/114.114.114.114
 server=/rojewel.com/114.114.114.114
 server=/rokeyyan.com/114.114.114.114
 server=/rokid.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -77653,7 +77653,6 @@ server=/thepotboiler.com/114.114.114.114
 server=/thepuli.com/114.114.114.114
 server=/therasaganga.com/114.114.114.114
 server=/thereszhaiproject.com/114.114.114.114
-server=/thesac3.top/114.114.114.114
 server=/theseshepherd.com/114.114.114.114
 server=/thesetech.com/114.114.114.114
 server=/thesmartmelon.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -62632,7 +62632,6 @@ server=/okcxo.com/114.114.114.114
 server=/okdai.com/114.114.114.114
 server=/okdcc.com/114.114.114.114
 server=/okdd.net/114.114.114.114
-server=/okdi.top/114.114.114.114
 server=/okead.com/114.114.114.114
 server=/okemu.com/114.114.114.114
 server=/okex.vip/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -62410,7 +62410,6 @@ server=/oaimai.com/114.114.114.114
 server=/oait360.com/114.114.114.114
 server=/oajdsr.xyz/114.114.114.114
 server=/oaklandjs.com/114.114.114.114
-server=/oakmn.top/114.114.114.114
 server=/oaloft.com/114.114.114.114
 server=/oaloft.net/114.114.114.114
 server=/oameibang.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -65005,7 +65005,6 @@ server=/pphimalayanrt.com/114.114.114.114
 server=/pphqq.com/114.114.114.114
 server=/ppio.cloud/114.114.114.114
 server=/ppio.work/114.114.114.114
-server=/ppio12200ios.top/114.114.114.114
 server=/ppj.io/114.114.114.114
 server=/ppjtc.net/114.114.114.114
 server=/ppkankan01.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -77657,7 +77657,6 @@ server=/theseshepherd.com/114.114.114.114
 server=/thesetech.com/114.114.114.114
 server=/thesmartmelon.com/114.114.114.114
 server=/thesofabedshop.com/114.114.114.114
-server=/thestack.top/114.114.114.114
 server=/theszt.com/114.114.114.114
 server=/thetali.com/114.114.114.114
 server=/thethirdmedia.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -89178,7 +89178,6 @@ server=/xtrunc.com/114.114.114.114
 server=/xtsfuke.com/114.114.114.114
 server=/xttaff.com/114.114.114.114
 server=/xttblog.com/114.114.114.114
-server=/xttv.top/114.114.114.114
 server=/xttz.com/114.114.114.114
 server=/xtu2.com/114.114.114.114
 server=/xtuan.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -69078,7 +69078,6 @@ server=/rrbus.com/114.114.114.114
 server=/rrchem.com/114.114.114.114
 server=/rrcimg.com/114.114.114.114
 server=/rrcp.com/114.114.114.114
-server=/rrdtjj.top/114.114.114.114
 server=/rrdtz.com/114.114.114.114
 server=/rree.com/114.114.114.114
 server=/rrfccx.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -64159,7 +64159,6 @@ server=/pgy6.com/114.114.114.114
 server=/pgyer.com/114.114.114.114
 server=/pgyidc.com/114.114.114.114
 server=/pgyy.com/114.114.114.114
-server=/pgyy67.top/114.114.114.114
 server=/pgzs.com/114.114.114.114
 server=/pgzx.net/114.114.114.114
 server=/ph-fc.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -80131,7 +80131,6 @@ server=/u9u9.com/114.114.114.114
 server=/u9wan.com/114.114.114.114
 server=/uaff7j.com/114.114.114.114
 server=/uahh.site/114.114.114.114
-server=/uaiqp.top/114.114.114.114
 server=/uakwj.com/114.114.114.114
 server=/uancf.com/114.114.114.114
 server=/uandi-wireless.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -88124,7 +88124,6 @@ server=/xiushao.com/114.114.114.114
 server=/xiusheji.com/114.114.114.114
 server=/xiushuang.com/114.114.114.114
 server=/xiusifudianji.com/114.114.114.114
-server=/xiuska.top/114.114.114.114
 server=/xiustatic.com/114.114.114.114
 server=/xiutanqi.com/114.114.114.114
 server=/xiutuan.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -75892,7 +75892,6 @@ server=/syttgame.com/114.114.114.114
 server=/sytuku.com/114.114.114.114
 server=/syuan.com/114.114.114.114
 server=/syuan.net/114.114.114.114
-server=/syuanz.top/114.114.114.114
 server=/syue.com/114.114.114.114
 server=/sywg.com/114.114.114.114
 server=/sywgy.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -80956,7 +80956,6 @@ server=/uugame.com/114.114.114.114
 server=/uugtv.com/114.114.114.114
 server=/uuhdedu.com/114.114.114.114
 server=/uuhimalayanqm.com/114.114.114.114
-server=/uuiaoq.top/114.114.114.114
 server=/uuid.online/114.114.114.114
 server=/uuimg.com/114.114.114.114
 server=/uuisoas.xyz/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -77814,7 +77814,6 @@ server=/tianhetech.com/114.114.114.114
 server=/tianhongdiaosu.com/114.114.114.114
 server=/tianhongsunshine.com/114.114.114.114
 server=/tianhujy.com/114.114.114.114
-server=/tianii.top/114.114.114.114
 server=/tianiot.com/114.114.114.114
 server=/tianji368.com/114.114.114.114
 server=/tianjiachem.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -80781,7 +80781,6 @@ server=/uqualities.com/114.114.114.114
 server=/uqude.com/114.114.114.114
 server=/uqufin.com/114.114.114.114
 server=/uqulive.com/114.114.114.114
-server=/uqwjdhgv.top/114.114.114.114
 server=/uqz.com/114.114.114.114
 server=/urart.cc/114.114.114.114
 server=/urbanchina.org/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -77731,7 +77731,6 @@ server=/ths8.com/114.114.114.114
 server=/thseoer.com/114.114.114.114
 server=/thstars.com/114.114.114.114
 server=/thtfpc.com/114.114.114.114
-server=/thuecn.top/114.114.114.114
 server=/thufeng.net/114.114.114.114
 server=/thumbenv.com/114.114.114.114
 server=/thumedialab.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -62716,7 +62716,6 @@ server=/oliver.ren/114.114.114.114
 server=/oliveryang.net/114.114.114.114
 server=/oliyi.com/114.114.114.114
 server=/ollomall.com/114.114.114.114
-server=/olmnvbgufy.top/114.114.114.114
 server=/olo4.com/114.114.114.114
 server=/oltfm.com/114.114.114.114
 server=/olwsz.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -73016,7 +73016,6 @@ server=/simpledatas.com/114.114.114.114
 server=/simplexue.com/114.114.114.114
 server=/simpread.pro/114.114.114.114
 server=/simsci.net/114.114.114.114
-server=/simsoft.top/114.114.114.114
 server=/simu800.com/114.114.114.114
 server=/simul-china.com/114.114.114.114
 server=/simullink.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -62343,7 +62343,6 @@ server=/nyxlzy.com/114.114.114.114
 server=/nyxr-home.com/114.114.114.114
 server=/nyxx365.com/114.114.114.114
 server=/nyxz166.com/114.114.114.114
-server=/nyzda.top/114.114.114.114
 server=/nyzdjj.com/114.114.114.114
 server=/nyzy.com/114.114.114.114
 server=/nz86.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -69453,7 +69453,6 @@ server=/rvmcu.com/114.114.114.114
 server=/rwb66.com/114.114.114.114
 server=/rwd.hk/114.114.114.114
 server=/rwdls.com/114.114.114.114
-server=/rwpt.top/114.114.114.114
 server=/rwtext.com/114.114.114.114
 server=/rwxqfbj.com/114.114.114.114
 server=/rwys.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -70510,7 +70510,6 @@ server=/sdmingjun.com/114.114.114.114
 server=/sdmtfy.com/114.114.114.114
 server=/sdmydcr.com/114.114.114.114
 server=/sdmyzsgs.com/114.114.114.114
-server=/sdnc.top/114.114.114.114
 server=/sdnci.com/114.114.114.114
 server=/sdndzb.com/114.114.114.114
 server=/sdnfv.org/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -98439,7 +98439,6 @@ server=/zyrb.com/114.114.114.114
 server=/zyrfanli.com/114.114.114.114
 server=/zyrj.org/114.114.114.114
 server=/zyrykbiandao.com/114.114.114.114
-server=/zys13.top/114.114.114.114
 server=/zys6d.com/114.114.114.114
 server=/zyskys.com/114.114.114.114
 server=/zysljhslt.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -86605,7 +86605,6 @@ server=/xhma.com/114.114.114.114
 server=/xhmedia.com/114.114.114.114
 server=/xhmwxy.com/114.114.114.114
 server=/xhnews.net/114.114.114.114
-server=/xhofe.top/114.114.114.114
 server=/xhostserver.com/114.114.114.114
 server=/xhpfw.com/114.114.114.114
 server=/xhpiano.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -80374,7 +80374,6 @@ server=/uhzcdn.com/114.114.114.114
 server=/ui-lab.com/114.114.114.114
 server=/ui100day.com/114.114.114.114
 server=/ui63.com/114.114.114.114
-server=/uiakq.top/114.114.114.114
 server=/uib110.com/114.114.114.114
 server=/uibep.com/114.114.114.114
 server=/uibim.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -81794,7 +81794,6 @@ server=/vn765.com/114.114.114.114
 server=/vnadssb.com/114.114.114.114
 server=/vname.com/114.114.114.114
 server=/vnanke.com/114.114.114.114
-server=/vncongthue.top/114.114.114.114
 server=/vndian.com/114.114.114.114
 server=/vnet.com/114.114.114.114
 server=/vnet.mobi/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -62626,7 +62626,6 @@ server=/okbmf.com/114.114.114.114
 server=/okbuy.com/114.114.114.114
 server=/okcard.com/114.114.114.114
 server=/okcdnns.com/114.114.114.114
-server=/okcf.top/114.114.114.114
 server=/okchang.com/114.114.114.114
 server=/okchexian.com/114.114.114.114
 server=/okcxo.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -69888,7 +69888,6 @@ server=/sardchina-lmgt.com/114.114.114.114
 server=/sarft.net/114.114.114.114
 server=/sascin.com/114.114.114.114
 server=/sasecurity.com/114.114.114.114
-server=/sason.top/114.114.114.114
 server=/sass.hk/114.114.114.114
 server=/sasscss.com/114.114.114.114
 server=/sasseur.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -80979,7 +80979,6 @@ server=/uupt.com/114.114.114.114
 server=/uus8.com/114.114.114.114
 server=/uusama.com/114.114.114.114
 server=/uusee.com/114.114.114.114
-server=/uusjaq.top/114.114.114.114
 server=/uusky.com/114.114.114.114
 server=/uusoo.net/114.114.114.114
 server=/uusos.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -67764,7 +67764,6 @@ server=/qwgg.com/114.114.114.114
 server=/qwgt.com/114.114.114.114
 server=/qwimm.com/114.114.114.114
 server=/qwolf.com/114.114.114.114
-server=/qwoofao.top/114.114.114.114
 server=/qwpo2018.com/114.114.114.114
 server=/qwps.net/114.114.114.114
 server=/qwq.link/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -82936,7 +82936,6 @@ server=/wdwd.com/114.114.114.114
 server=/wdwlb.com/114.114.114.114
 server=/wdxmzy.com/114.114.114.114
 server=/wdxtub.com/114.114.114.114
-server=/wdxxx.top/114.114.114.114
 server=/wdy33.com/114.114.114.114
 server=/wdy44.com/114.114.114.114
 server=/wdyxgames.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -67225,7 +67225,6 @@ server=/qu247.com/114.114.114.114
 server=/qu67.com/114.114.114.114
 server=/qua.com/114.114.114.114
 server=/qualcomm-challenge.com/114.114.114.114
-server=/qualitycloud.top/114.114.114.114
 server=/quan.mx/114.114.114.114
 server=/quan007.com/114.114.114.114
 server=/quan365.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -89001,7 +89001,6 @@ server=/xrdyl.com/114.114.114.114
 server=/xrdzidonghua.com/114.114.114.114
 server=/xredu.com/114.114.114.114
 server=/xrender.com/114.114.114.114
-server=/xrgzs.top/114.114.114.114
 server=/xrhhg.com/114.114.114.114
 server=/xrichengapp.com/114.114.114.114
 server=/xrkapp.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -95752,7 +95752,6 @@ server=/zhenguanyu.biz/114.114.114.114
 server=/zhenguanyu.com/114.114.114.114
 server=/zhenguo.com/114.114.114.114
 server=/zhengwei007.com/114.114.114.114
-server=/zhengwei3.top/114.114.114.114
 server=/zhengwutong.com/114.114.114.114
 server=/zhengxiaoling.com/114.114.114.114
 server=/zhengxin51.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -63152,7 +63152,6 @@ server=/osgervirtual.com/114.114.114.114
 server=/osgraph.com/114.114.114.114
 server=/osgz.com/114.114.114.114
 server=/oshadan.com/114.114.114.114
-server=/oshaq.top/114.114.114.114
 server=/oshome.com/114.114.114.114
 server=/oshoplive.com/114.114.114.114
 server=/oshwhub.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -85212,7 +85212,6 @@ server=/wsy7.com/114.114.114.114
 server=/wsyglngy.com/114.114.114.114
 server=/wsyhn.com/114.114.114.114
 server=/wszwhg.net/114.114.114.114
-server=/wszzb.top/114.114.114.114
 server=/wt-tech.com/114.114.114.114
 server=/wt168.com/114.114.114.114
 server=/wt222.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -82839,7 +82839,6 @@ server=/wbb-electric.com/114.114.114.114
 server=/wbbcdn.com/114.114.114.114
 server=/wbcm55.com/114.114.114.114
 server=/wbd99.com/114.114.114.114
-server=/wbdsj.top/114.114.114.114
 server=/wbgt.net/114.114.114.114
 server=/wbhgwbnd.com/114.114.114.114
 server=/wbiao.co/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -80131,7 +80131,6 @@ server=/u9u9.com/114.114.114.114
 server=/u9wan.com/114.114.114.114
 server=/uaff7j.com/114.114.114.114
 server=/uahh.site/114.114.114.114
-server=/uaiosio.top/114.114.114.114
 server=/uaiqp.top/114.114.114.114
 server=/uakwj.com/114.114.114.114
 server=/uancf.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -79355,7 +79355,6 @@ server=/ttfly.com/114.114.114.114
 server=/ttfuav.com/114.114.114.114
 server=/ttg8.com/114.114.114.114
 server=/ttgan.com/114.114.114.114
-server=/ttgbnmk.top/114.114.114.114
 server=/ttge.ru/114.114.114.114
 server=/ttgjx.com/114.114.114.114
 server=/ttgslb.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -74035,7 +74035,6 @@ server=/solarbe.com/114.114.114.114
 server=/solarbio.com/114.114.114.114
 server=/solarchin.com/114.114.114.114
 server=/solaridc.com/114.114.114.114
-server=/solaron.top/114.114.114.114
 server=/solasmat.com/114.114.114.114
 server=/soldeazy.com/114.114.114.114
 server=/soldierstory-toys.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -93582,7 +93582,6 @@ server=/yujpa.com/114.114.114.114
 server=/yujunjie.com/114.114.114.114
 server=/yujunren.com/114.114.114.114
 server=/yujzw.com/114.114.114.114
-server=/yukaidi.top/114.114.114.114
 server=/yukaiprecision.com/114.114.114.114
 server=/yukapril.com/114.114.114.114
 server=/yukeinfo.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -73042,7 +73042,6 @@ server=/sinaif.com/114.114.114.114
 server=/sinaimg.com/114.114.114.114
 server=/sinalog.com/114.114.114.114
 server=/sinaluming.com/114.114.114.114
-server=/sinam.top/114.114.114.114
 server=/sinan.fun/114.114.114.114
 server=/sinanet.com/114.114.114.114
 server=/sinanya.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -80943,7 +80943,6 @@ server=/uu89.com/114.114.114.114
 server=/uu898.com/114.114.114.114
 server=/uu8okm.xyz/114.114.114.114
 server=/uuaa.net/114.114.114.114
-server=/uuajq.top/114.114.114.114
 server=/uuboos.com/114.114.114.114
 server=/uucl.vip/114.114.114.114
 server=/uucnn.com/114.114.114.114


### PR DESCRIPTION
1. Add domains
More than 1K+ domains added. The domains added this time all contain NS servers in multiple different countries, and each domain has at least one NS server located in China mainland.

3. Remove domains
All .top domains have been removed. Only /top/ remains.