### PR TITLE
Update accelerated-domains.china.conf

### DIFF
--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -21747,6 +21747,7 @@ server=/cniiib.com/114.114.114.114
 server=/cnimg.elex.com/114.114.114.114
 server=/cninfo.net/114.114.114.114
 server=/cninfos.com/114.114.114.114
+server=/cninj.com/114.114.114.114
 server=/cninnovatel.com/114.114.114.114
 server=/cninternetdownloadmanager.com/114.114.114.114
 server=/cnipa-gd.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -61764,6 +61764,7 @@ server=/netentsec.com/114.114.114.114
 server=/netesee.com/114.114.114.114
 server=/netflew.com/114.114.114.114
 server=/netgamecar.com/114.114.114.114
+server=/netge.com/114.114.114.114
 server=/netherlandvcenter.com/114.114.114.114
 server=/nethonghe.com/114.114.114.114
 server=/netianshannu.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -76880,6 +76880,7 @@ server=/sumaart.com/114.114.114.114
 server=/sumaarts.com/114.114.114.114
 server=/sumatang.com/114.114.114.114
 server=/sumavision.com/114.114.114.114
+server=/sumec.com/114.114.114.114
 server=/sumedu.com/114.114.114.114
 server=/sumeme.com/114.114.114.114
 server=/sumer.work/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -62551,6 +62551,7 @@ server=/njtst.com/114.114.114.114
 server=/njuftp.org/114.114.114.114
 server=/njuoe.com/114.114.114.114
 server=/njustar.com/114.114.114.114
+server=/njuup.com/114.114.114.114
 server=/njuwh.com/114.114.114.114
 server=/njw88.com/114.114.114.114
 server=/njweiyi6.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -56569,6 +56569,7 @@ server=/luhe.net/114.114.114.114
 server=/luhehospital.com/114.114.114.114
 server=/luhu.co/114.114.114.114
 server=/luhua.cc/114.114.114.114
+server=/luhuadong.com/114.114.114.114
 server=/luhuaseed.com/114.114.114.114
 server=/lujiaming.com/114.114.114.114
 server=/lujiandairy.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -31521,6 +31521,7 @@ server=/foreseamall.com/114.114.114.114
 server=/foresightfund.com/114.114.114.114
 server=/foresl.com/114.114.114.114
 server=/forestfood.com/114.114.114.114
+server=/forestmusicnanjing.com/114.114.114.114
 server=/forestpolice.org/114.114.114.114
 server=/foreveross.com/114.114.114.114
 server=/forface3d.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -62441,6 +62441,7 @@ server=/njjuntong.com/114.114.114.114
 server=/njjwkj.com/114.114.114.114
 server=/njjydt.com/114.114.114.114
 server=/njjz.net/114.114.114.114
+server=/njjzyxh.com/114.114.114.114
 server=/njkaifeng.com/114.114.114.114
 server=/njkaiguan.com/114.114.114.114
 server=/njkcsj.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -61633,6 +61633,7 @@ server=/ndsyy.com/114.114.114.114
 server=/ndszgb.com/114.114.114.114
 server=/nduoa.com/114.114.114.114
 server=/nduotuan.com/114.114.114.114
+server=/ndxlj.com/114.114.114.114
 server=/ndyt.com/114.114.114.114
 server=/ndzfl.com/114.114.114.114
 server=/ndzls.net/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -62450,6 +62450,7 @@ server=/njjianguo.com/114.114.114.114
 server=/njjknkyy.com/114.114.114.114
 server=/njjn.com/114.114.114.114
 server=/njjnwzyy.com/114.114.114.114
+server=/njjnzc.com/114.114.114.114
 server=/njjrc.com/114.114.114.114
 server=/njjrkj.com/114.114.114.114
 server=/njjrlf.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -62495,6 +62495,7 @@ server=/njpud.com/114.114.114.114
 server=/njpujiang.com/114.114.114.114
 server=/njq.net/114.114.114.114
 server=/njqhjy.net/114.114.114.114
+server=/njqixiashan.com/114.114.114.114
 server=/njqxrc.com/114.114.114.114
 server=/njrmzx.com/114.114.114.114
 server=/njrnk.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -87168,6 +87168,7 @@ server=/wscdns.com/114.114.114.114
 server=/wscdns.info/114.114.114.114
 server=/wscdns.org/114.114.114.114
 server=/wscdnss.com/114.114.114.114
+server=/wsce-expo.com/114.114.114.114
 server=/wscgdns.com/114.114.114.114
 server=/wsche.com/114.114.114.114
 server=/wscloudcdn.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -100175,6 +100175,7 @@ server=/zslyzjj11.com/114.114.114.114
 server=/zsmama.com/114.114.114.114
 server=/zsmw.net/114.114.114.114
 server=/zsnxapp.com/114.114.114.114
+server=/zspharm.com/114.114.114.114
 server=/zsppsj.com/114.114.114.114
 server=/zsquant.com/114.114.114.114
 server=/zsr.cc/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -29648,6 +29648,7 @@ server=/excbio.com/114.114.114.114
 server=/excean.com/114.114.114.114
 server=/exceedconn.com/114.114.114.114
 server=/excegroup.com/114.114.114.114
+server=/excegroupur.com/114.114.114.114
 server=/excel8.com/114.114.114.114
 server=/excel880.com/114.114.114.114
 server=/excelcn.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -54539,6 +54539,7 @@ server=/lhdeer.com/114.114.114.114
 server=/lhdown.com/114.114.114.114
 server=/lhdwx.com/114.114.114.114
 server=/lhdxz.com/114.114.114.114
+server=/lhenet.net/114.114.114.114
 server=/lhey.com/114.114.114.114
 server=/lhgcxx.com/114.114.114.114
 server=/lhguomy.xyz/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -74887,6 +74887,7 @@ server=/siscantech.com/114.114.114.114
 server=/siscmag.com/114.114.114.114
 server=/sisen.com/114.114.114.114
 server=/sisensing.com/114.114.114.114
+server=/sishuojixie.com/114.114.114.114
 server=/sishuok.com/114.114.114.114
 server=/sishuxuefu.com/114.114.114.114
 server=/sisigad.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -72608,6 +72608,7 @@ server=/sh-minghui.com/114.114.114.114
 server=/sh-ncn.com/114.114.114.114
 server=/sh-nemoto.com/114.114.114.114
 server=/sh-pp.com/114.114.114.114
+server=/sh-printing.com/114.114.114.114
 server=/sh-prosperity.com/114.114.114.114
 server=/sh-prosun.com/114.114.114.114
 server=/sh-putai.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -62471,6 +62471,7 @@ server=/njlonsen.com/114.114.114.114
 server=/njlrxx.com/114.114.114.114
 server=/njlsw.com/114.114.114.114
 server=/njltxx.com/114.114.114.114
+server=/njlyc.com/114.114.114.114
 server=/njlzsx.net/114.114.114.114
 server=/njmama.com/114.114.114.114
 server=/njmapp.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -25068,6 +25068,7 @@ server=/dehuisk.com/114.114.114.114
 server=/dehuiyuan.com/114.114.114.114
 server=/deifgs.com/114.114.114.114
 server=/deikuo.com/114.114.114.114
+server=/dejiart.com/114.114.114.114
 server=/dejinfu365.com/114.114.114.114
 server=/dejiplaza.com/114.114.114.114
 server=/dekeego.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -62631,6 +62631,7 @@ server=/njzychemical.com/114.114.114.114
 server=/njzztyl.com/114.114.114.114
 server=/nk-sh.com/114.114.114.114
 server=/nkdgnsfsk.com/114.114.114.114
+server=/nkf-pharma.com/114.114.114.114
 server=/nks1688.com/114.114.114.114
 server=/nkscdn.com/114.114.114.114
 server=/nkygty.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -62424,6 +62424,7 @@ server=/njhszoo.com/114.114.114.114
 server=/njhuachuang.com/114.114.114.114
 server=/njhuatong.com/114.114.114.114
 server=/njhuazhu.com/114.114.114.114
+server=/njhunyan.com/114.114.114.114
 server=/njhxnpx.com/114.114.114.114
 server=/njhxzx.com/114.114.114.114
 server=/njhy-tech.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -62359,6 +62359,7 @@ server=/njctcm.com/114.114.114.114
 server=/njcttq.com/114.114.114.114
 server=/njcw.com/114.114.114.114
 server=/njcwlk.com/114.114.114.114
+server=/njcxj.com/114.114.114.114
 server=/njcyt99.com/114.114.114.114
 server=/njd1.com/114.114.114.114
 server=/njdapaidang.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -62288,6 +62288,7 @@ server=/nj-hust.com/114.114.114.114
 server=/nj-nanhuai.com/114.114.114.114
 server=/nj-netgalaxy.com/114.114.114.114
 server=/nj-qiyiguo.net/114.114.114.114
+server=/nj-reagent.com/114.114.114.114
 server=/nj-ss.com/114.114.114.114
 server=/nj-tencentclb.cloud/114.114.114.114
 server=/nj-test.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -62432,6 +62432,7 @@ server=/njibhu.com/114.114.114.114
 server=/njibmfwq.com/114.114.114.114
 server=/njicg.com/114.114.114.114
 server=/njiec.com/114.114.114.114
+server=/njiig.com/114.114.114.114
 server=/njimi.com/114.114.114.114
 server=/njjbrmyy.net/114.114.114.114
 server=/njjcbio.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -81838,6 +81838,7 @@ server=/txlctong.com/114.114.114.114
 server=/txlivecdn.com/114.114.114.114
 server=/txlt.com/114.114.114.114
 server=/txlunwenw.com/114.114.114.114
+server=/txlzp.com/114.114.114.114
 server=/txmcu.com/114.114.114.114
 server=/txmkf.com/114.114.114.114
 server=/txon.net/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -9389,6 +9389,7 @@ server=/adiexpress.com/114.114.114.114
 server=/adigifactory.com/114.114.114.114
 server=/adiic.com/114.114.114.114
 server=/adinall.com/114.114.114.114
+server=/adinju.com/114.114.114.114
 server=/adinsurecrm.com/114.114.114.114
 server=/adipman.net/114.114.114.114
 server=/adjdds.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -55053,6 +55053,7 @@ server=/lingqumall.com/114.114.114.114
 server=/lingrengame.com/114.114.114.114
 server=/lingrn.com/114.114.114.114
 server=/lingruipc.com/114.114.114.114
+server=/lingruofeng.com/114.114.114.114
 server=/lingshangkaihua.com/114.114.114.114
 server=/lingshangmeien.com/114.114.114.114
 server=/lingshi.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -62258,6 +62258,7 @@ server=/niuqia.com/114.114.114.114
 server=/niurenqushi.com/114.114.114.114
 server=/niuschools.com/114.114.114.114
 server=/niushe.com/114.114.114.114
+server=/niushoushan.net/114.114.114.114
 server=/niutech.com/114.114.114.114
 server=/niutk.com/114.114.114.114
 server=/niutoushe.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -62327,6 +62327,7 @@ server=/nj29jt.net/114.114.114.114
 server=/nj303yy.com/114.114.114.114
 server=/nj63.com/114.114.114.114
 server=/nj87.com/114.114.114.114
+server=/njadi.com/114.114.114.114
 server=/njajjt.com/114.114.114.114
 server=/njaoti.com/114.114.114.114
 server=/njatl.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -62305,6 +62305,7 @@ server=/nj-halfmarathon.com/114.114.114.114
 server=/nj-hr.com/114.114.114.114
 server=/nj-huaqiang.com/114.114.114.114
 server=/nj-hust.com/114.114.114.114
+server=/nj-kejin.com/114.114.114.114
 server=/nj-nanhuai.com/114.114.114.114
 server=/nj-netgalaxy.com/114.114.114.114
 server=/nj-qiyiguo.net/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -62631,6 +62631,7 @@ server=/njzhituo.com/114.114.114.114
 server=/njzhzx.net/114.114.114.114
 server=/njzj.net/114.114.114.114
 server=/njzqzs.com/114.114.114.114
+server=/njzsgroup.com/114.114.114.114
 server=/njzychemical.com/114.114.114.114
 server=/njzztyl.com/114.114.114.114
 server=/nk-sh.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -48605,6 +48605,7 @@ server=/jinletx.com/114.114.114.114
 server=/jinlianchu.com/114.114.114.114
 server=/jinlinghotel.com/114.114.114.114
 server=/jinlinghotels.com/114.114.114.114
+server=/jinlingjiajiao.com/114.114.114.114
 server=/jinliniuan.com/114.114.114.114
 server=/jinlishenghuo.com/114.114.114.114
 server=/jinliyang.net/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -50600,6 +50600,7 @@ server=/jwsaas.com/114.114.114.114
 server=/jwsem.com/114.114.114.114
 server=/jwshy.com/114.114.114.114
 server=/jwsm123.com/114.114.114.114
+server=/jwtherapeutics.com/114.114.114.114
 server=/jwview.com/114.114.114.114
 server=/jwwey.com/114.114.114.114
 server=/jwygou.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -71430,6 +71430,7 @@ server=/scbt.asia/114.114.114.114
 server=/scbxmr.com/114.114.114.114
 server=/scbyx.net/114.114.114.114
 server=/scbz120.com/114.114.114.114
+server=/sccchina.net/114.114.114.114
 server=/scccyts.com/114.114.114.114
 server=/sccens.net/114.114.114.114
 server=/sccin.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -73585,6 +73585,7 @@ server=/shine-ic.com/114.114.114.114
 server=/shinechina.com/114.114.114.114
 server=/shinefeel.com/114.114.114.114
 server=/shinelon.com/114.114.114.114
+server=/shineoptics.com/114.114.114.114
 server=/shinerayad.com/114.114.114.114
 server=/shinetsu.shop/114.114.114.114
 server=/shineu.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -62580,6 +62580,7 @@ server=/njwsp.com/114.114.114.114
 server=/njwtqx.com/114.114.114.114
 server=/njwuhe.com/114.114.114.114
 server=/njwww.net/114.114.114.114
+server=/njwz.net/114.114.114.114
 server=/njwzjsw.com/114.114.114.114
 server=/njxax.com/114.114.114.114
 server=/njxiaochi.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -62482,6 +62482,7 @@ server=/njmapp.com/114.114.114.114
 server=/njmbwxzx.com/114.114.114.114
 server=/njmdzx.net/114.114.114.114
 server=/njmeisai.com/114.114.114.114
+server=/njmes.org/114.114.114.114
 server=/njmjzn.com/114.114.114.114
 server=/njmkt.com/114.114.114.114
 server=/njml120.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -22996,6 +22996,7 @@ server=/crazyphper.com/114.114.114.114
 server=/crazypm.com/114.114.114.114
 server=/crazyrtc.com/114.114.114.114
 server=/crazywong.com/114.114.114.114
+server=/crbbg.com/114.114.114.114
 server=/crbeverage.com/114.114.114.114
 server=/crc.com.hk/114.114.114.114
 server=/crc.hk/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -30483,6 +30483,7 @@ server=/fe2x.cc/114.114.114.114
 server=/fe520.com/114.114.114.114
 server=/feadi.com/114.114.114.114
 server=/feanton.com/114.114.114.114
+server=/featchina.com/114.114.114.114
 server=/fecmall.com/114.114.114.114
 server=/fecn.net/114.114.114.114
 server=/fecshop.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -62359,6 +62359,7 @@ server=/njfmyd.com/114.114.114.114
 server=/njfmz.com/114.114.114.114
 server=/njforge.com/114.114.114.114
 server=/njfybjy.com/114.114.114.114
+server=/njfzm.net/114.114.114.114
 server=/njgb.com/114.114.114.114
 server=/njgcyy.com/114.114.114.114
 server=/njgdbus.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -97198,6 +97198,7 @@ server=/ze-mp.com/114.114.114.114
 server=/ze-wx.com/114.114.114.114
 server=/ze13.com/114.114.114.114
 server=/ze5.com/114.114.114.114
+server=/zeaho.com/114.114.114.114
 server=/zealer.com/114.114.114.114
 server=/zeali.net/114.114.114.114
 server=/zealquest.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -49486,6 +49486,7 @@ server=/job1001.com/114.114.114.114
 server=/job11580.com/114.114.114.114
 server=/job120.com/114.114.114.114
 server=/job168.com/114.114.114.114
+server=/job225.com/114.114.114.114
 server=/job256.com/114.114.114.114
 server=/job263.com/114.114.114.114
 server=/job36.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -62577,6 +62577,7 @@ server=/njtrh.com/114.114.114.114
 server=/njtst.com/114.114.114.114
 server=/njuftp.org/114.114.114.114
 server=/njuoe.com/114.114.114.114
+server=/njupco.com/114.114.114.114
 server=/njustar.com/114.114.114.114
 server=/njuup.com/114.114.114.114
 server=/njuwh.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -49937,6 +49937,7 @@ server=/jsjjy.com/114.114.114.114
 server=/jsjkx.com/114.114.114.114
 server=/jsjljy.com/114.114.114.114
 server=/jsjnsw.com/114.114.114.114
+server=/jsjnw.org/114.114.114.114
 server=/jsjs.cc/114.114.114.114
 server=/jsjs1982.com/114.114.114.114
 server=/jsjslk.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -18527,6 +18527,7 @@ server=/cfxinzhushou.com/114.114.114.114
 server=/cfxydefsyy.com/114.114.114.114
 server=/cfxyfsyy.com/114.114.114.114
 server=/cfxyjy.com/114.114.114.114
+server=/cfyedu.com/114.114.114.114
 server=/cfyy.cc/114.114.114.114
 server=/cfyzs.com/114.114.114.114
 server=/cfzhgm.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -85156,6 +85156,7 @@ server=/weifenpay.com/114.114.114.114
 server=/weiforyou.net/114.114.114.114
 server=/weifrom.com/114.114.114.114
 server=/weifujd.com/114.114.114.114
+server=/weigangdairy.com/114.114.114.114
 server=/weigangqin.com/114.114.114.114
 server=/weigay.com/114.114.114.114
 server=/weige55.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -2154,6 +2154,7 @@ server=/192sm.com/114.114.114.114
 server=/1931.com/114.114.114.114
 server=/1934xjzy.com/114.114.114.114
 server=/1937cn.com/114.114.114.114
+server=/1937nanjing.org/114.114.114.114
 server=/193839.com/114.114.114.114
 server=/193sihu.com/114.114.114.114
 server=/194610.xyz/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -15431,6 +15431,7 @@ server=/bkjpress.com/114.114.114.114
 server=/bkjsemi.com/114.114.114.114
 server=/bkn.cc/114.114.114.114
 server=/bkneng.com/114.114.114.114
+server=/bknzdh.com/114.114.114.114
 server=/bkpcn.com/114.114.114.114
 server=/bkqq.com/114.114.114.114
 server=/bkt123.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -21876,6 +21876,7 @@ server=/cnmsn.com/114.114.114.114
 server=/cnmsn.net/114.114.114.114
 server=/cnmstl.net/114.114.114.114
 server=/cnmtpt.com/114.114.114.114
+server=/cnmuseum.com/114.114.114.114
 server=/cnnage.com/114.114.114.114
 server=/cnnaihuo.com/114.114.114.114
 server=/cnnb.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -48108,6 +48108,7 @@ server=/jiayusx.com/114.114.114.114
 server=/jiazaishanghai.com/114.114.114.114
 server=/jiazhao.com/114.114.114.114
 server=/jiazhao7.com/114.114.114.114
+server=/jiazhaoba.com/114.114.114.114
 server=/jiazhi.online/114.114.114.114
 server=/jiazhichem.com/114.114.114.114
 server=/jiazhongkeji.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -28722,6 +28722,7 @@ server=/ehutu.com/114.114.114.114
 server=/ehuzhu.com/114.114.114.114
 server=/ehxyz.com/114.114.114.114
 server=/ei6nd.com/114.114.114.114
+server=/eia-data.com/114.114.114.114
 server=/eia543.com/114.114.114.114
 server=/eiafans.com/114.114.114.114
 server=/eiccmall.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -62299,6 +62299,7 @@ server=/nj-bl.com/114.114.114.114
 server=/nj-chishun.com/114.114.114.114
 server=/nj-gw.com/114.114.114.114
 server=/nj-halfmarathon.com/114.114.114.114
+server=/nj-hr.com/114.114.114.114
 server=/nj-huaqiang.com/114.114.114.114
 server=/nj-hust.com/114.114.114.114
 server=/nj-nanhuai.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -62608,6 +62608,7 @@ server=/njyjglxh.com/114.114.114.114
 server=/njyjxh.com/114.114.114.114
 server=/njyouwin.com/114.114.114.114
 server=/njyshb.com/114.114.114.114
+server=/njysw.com/114.114.114.114
 server=/njytian.com/114.114.114.114
 server=/njyule.club/114.114.114.114
 server=/njyxdq.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -23428,6 +23428,7 @@ server=/ctrip.my/114.114.114.114
 server=/ctrip.sg/114.114.114.114
 server=/ctripbiz.com/114.114.114.114
 server=/ctripbuy.hk/114.114.114.114
+server=/ctripc.com/114.114.114.114
 server=/ctripcorp.com/114.114.114.114
 server=/ctripgslb.com/114.114.114.114
 server=/ctripins.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -42812,6 +42812,7 @@ server=/huawan.com/114.114.114.114
 server=/huawangyinshuachang.com/114.114.114.114
 server=/huawangzhixun.com/114.114.114.114
 server=/huawanyun.com/114.114.114.114
+server=/huawe.com/114.114.114.114
 server=/huawei-3com.com/114.114.114.114
 server=/huawei.asia/114.114.114.114
 server=/huawei.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -74486,6 +74486,7 @@ server=/shzjy.com/114.114.114.114
 server=/shzkb.com/114.114.114.114
 server=/shzkbc.com/114.114.114.114
 server=/shzkbj.com/114.114.114.114
+server=/shzn-group.com/114.114.114.114
 server=/shzq.com/114.114.114.114
 server=/shzrx.com/114.114.114.114
 server=/shzsun.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -63591,6 +63591,7 @@ server=/nxxzyimg.com/114.114.114.114
 server=/nxyqs.com/114.114.114.114
 server=/nxyqs.net/114.114.114.114
 server=/nxyy.asia/114.114.114.114
+server=/nxzhnyyjy.com/114.114.114.114
 server=/nxzkjsjt.com/114.114.114.114
 server=/ny-yy.com/114.114.114.114
 server=/nya.ink/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -62410,6 +62410,7 @@ server=/njhy-tech.com/114.114.114.114
 server=/njhzypiano.com/114.114.114.114
 server=/njiairport.com/114.114.114.114
 server=/njibhu.com/114.114.114.114
+server=/njibmfwq.com/114.114.114.114
 server=/njicg.com/114.114.114.114
 server=/njiec.com/114.114.114.114
 server=/njimi.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -41931,6 +41931,7 @@ server=/hotcoin.com/114.114.114.114
 server=/hotdb.com/114.114.114.114
 server=/hoteamsoft.com/114.114.114.114
 server=/hoteastday.com/114.114.114.114
+server=/hotelbaijin.com/114.114.114.114
 server=/hotelcis.com/114.114.114.114
 server=/hoteldig.com/114.114.114.114
 server=/hotelgg.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -79526,6 +79526,7 @@ server=/thejamy.com/114.114.114.114
 server=/thejiangmen.com/114.114.114.114
 server=/thejie.com/114.114.114.114
 server=/thejoyrun.com/114.114.114.114
+server=/thelalu.com/114.114.114.114
 server=/thelarkcloud.com/114.114.114.114
 server=/thelastsky.com/114.114.114.114
 server=/theluxfarm.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -100453,6 +100453,7 @@ server=/zuoshouyisheng.com/114.114.114.114
 server=/zuoshujiang.com/114.114.114.114
 server=/zuotishi.com/114.114.114.114
 server=/zuowen.com/114.114.114.114
+server=/zuowen.net/114.114.114.114
 server=/zuowen8.com/114.114.114.114
 server=/zuowenjing.com/114.114.114.114
 server=/zuowenjun.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -61294,6 +61294,7 @@ server=/nanhuwang.com/114.114.114.114
 server=/nanjing.com/114.114.114.114
 server=/nanjingbyby.com/114.114.114.114
 server=/nanjingchenxi.com/114.114.114.114
+server=/nanjinggaopeng.com/114.114.114.114
 server=/nanjinghuihe.com/114.114.114.114
 server=/nanjinghuojia.net/114.114.114.114
 server=/nanjingkaishan.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -49446,6 +49446,7 @@ server=/jnshijia.com/114.114.114.114
 server=/jnshu.com/114.114.114.114
 server=/jnskqyy.com/114.114.114.114
 server=/jnslyy.com/114.114.114.114
+server=/jnsms.com/114.114.114.114
 server=/jnstdc.com/114.114.114.114
 server=/jnszhqyy.com/114.114.114.114
 server=/jntinchina.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -43474,6 +43474,7 @@ server=/hurom.vip/114.114.114.114
 server=/hurricane618.me/114.114.114.114
 server=/hurricanechip.com/114.114.114.114
 server=/hurun.net/114.114.114.114
+server=/hurys.com/114.114.114.114
 server=/husenji.com/114.114.114.114
 server=/hushangcaifu.com/114.114.114.114
 server=/husini.net/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -80562,6 +80562,7 @@ server=/tongwang.net/114.114.114.114
 server=/tongxiang.net/114.114.114.114
 server=/tongxianghuicn.com/114.114.114.114
 server=/tongxiangshun.com/114.114.114.114
+server=/tongxiclub.com/114.114.114.114
 server=/tongxiehui.net/114.114.114.114
 server=/tongxin.com/114.114.114.114
 server=/tongxin.org/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -53946,6 +53946,7 @@ server=/ld173.com/114.114.114.114
 server=/ld246.com/114.114.114.114
 server=/ldaq2005.com/114.114.114.114
 server=/ldbc.net/114.114.114.114
+server=/ldbj.com/114.114.114.114
 server=/ldbmcs.com/114.114.114.114
 server=/ldd.me/114.114.114.114
 server=/lddengine.com/114.114.114.114


### PR DESCRIPTION
1. Add domains
A total of 2100+ new domain names have been added, all of which have NS servers located in Chinese Mainland.

2. Remove domains
Due to this issue (https://github.com/felixonmars/dnsmasq-china-list/issues/639), all domains containing Chinese characters have been removed.
The domains were re-added in Punycode format.