### PR TITLE
Update accelerated-domains.china.conf

### DIFF
--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -83742,6 +83742,7 @@ server=/ticstore.com/114.114.114.114
 server=/ticwear.com/114.114.114.114
 server=/tidb.io/114.114.114.114
 server=/tidb.net/114.114.114.114
+server=/tide-china.com/114.114.114.114
 server=/tide.fm/114.114.114.114
 server=/tidemedia.com/114.114.114.114
 server=/tidepharm.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -67327,6 +67327,7 @@ server=/ooyyee.com/114.114.114.114
 server=/op86.net/114.114.114.114
 server=/opadlink.com/114.114.114.114
 server=/opahnet.com/114.114.114.114
+server=/opal-qt.com/114.114.114.114
 server=/opark.com/114.114.114.114
 server=/opatseg.com/114.114.114.114
 server=/opcool.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -81320,6 +81320,7 @@ server=/synball.com/114.114.114.114
 server=/sync.sh/114.114.114.114
 server=/syncedoffplanet.com/114.114.114.114
 server=/syncozymes.com/114.114.114.114
+server=/syngars.com/114.114.114.114
 server=/syngenemed.com/114.114.114.114
 server=/synjones.com/114.114.114.114
 server=/synjones.net/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -85809,6 +85809,7 @@ server=/tydns.cc/114.114.114.114
 server=/tyfc.xyz/114.114.114.114
 server=/tyfo.com/114.114.114.114
 server=/tygameworld.com/114.114.114.114
+server=/tygckj.com/114.114.114.114
 server=/tyguocao.com/114.114.114.114
 server=/tyhjzx.com/114.114.114.114
 server=/tyi365.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -73385,6 +73385,7 @@ server=/rhce.cc/114.114.114.114
 server=/rhcqmu.com/114.114.114.114
 server=/rhctwy.com/114.114.114.114
 server=/rhcyl.com/114.114.114.114
+server=/rheaeco.com/114.114.114.114
 server=/rheemchina.com/114.114.114.114
 server=/rhexe.com/114.114.114.114
 server=/rhhz.net/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -103866,6 +103866,7 @@ server=/zizizaizai.com/114.114.114.114
 server=/zizizizizi.com/114.114.114.114
 server=/zizzs.com/114.114.114.114
 server=/zj-art.com/114.114.114.114
+server=/zj-ccmi.com/114.114.114.114
 server=/zj-echo.com/114.114.114.114
 server=/zj-equation.com/114.114.114.114
 server=/zj-fhzx.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -103942,6 +103942,7 @@ server=/zjcrcgas.com/114.114.114.114
 server=/zjcrjzj.com/114.114.114.114
 server=/zjcshjt.com/114.114.114.114
 server=/zjctct.com/114.114.114.114
+server=/zjctm.net/114.114.114.114
 server=/zjcuhb.com/114.114.114.114
 server=/zjcxbank.com/114.114.114.114
 server=/zjcywx.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -104211,6 +104211,7 @@ server=/zjradiology.org/114.114.114.114
 server=/zjrc.com/114.114.114.114
 server=/zjrc.net/114.114.114.114
 server=/zjrcu.com/114.114.114.114
+server=/zjrdl.com/114.114.114.114
 server=/zjriji.com/114.114.114.114
 server=/zjrob.com/114.114.114.114
 server=/zjrongli.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -104100,6 +104100,7 @@ server=/zjjlvyou8264.com/114.114.114.114
 server=/zjjm.net/114.114.114.114
 server=/zjjmtl.com/114.114.114.114
 server=/zjjn.com/114.114.114.114
+server=/zjjnzyjx.com/114.114.114.114
 server=/zjjr.com/114.114.114.114
 server=/zjjrh.com/114.114.114.114
 server=/zjjrtv.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -82983,6 +82983,7 @@ server=/temch.net/114.114.114.114
 server=/temox.com/114.114.114.114
 server=/temp.im/114.114.114.114
 server=/temut1.com/114.114.114.114
+server=/tenag.com/114.114.114.114
 server=/tenbilliongame.com/114.114.114.114
 server=/tencdns.com/114.114.114.114
 server=/tencdns.net/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -7501,6 +7501,7 @@ server=/81guofang.com/114.114.114.114
 server=/81it.com/114.114.114.114
 server=/81js.net/114.114.114.114
 server=/81kx.com/114.114.114.114
+server=/81lcd.com/114.114.114.114
 server=/81man.com/114.114.114.114
 server=/81pan.com/114.114.114.114
 server=/81tech.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -44837,6 +44837,7 @@ server=/huayanghui.net/114.114.114.114
 server=/huayanwater.com/114.114.114.114
 server=/huayaocc.com/114.114.114.114
 server=/huayaody.com/114.114.114.114
+server=/huaye.com/114.114.114.114
 server=/huayi-ks.com/114.114.114.114
 server=/huayicn.com/114.114.114.114
 server=/huayidiaosu.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -69133,6 +69133,7 @@ server=/pl520.com/114.114.114.114
 server=/pl999.com/114.114.114.114
 server=/plaidc.com/114.114.114.114
 server=/plalzhang.com/114.114.114.114
+server=/planary-yz.com/114.114.114.114
 server=/planckled.com/114.114.114.114
 server=/planetariuminsight.site/114.114.114.114
 server=/planetarylighting.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -102997,6 +102997,7 @@ server=/zhjncb.com/114.114.114.114
 server=/zhjp.net/114.114.114.114
 server=/zhjtaq.com/114.114.114.114
 server=/zhjtx.com/114.114.114.114
+server=/zhjuche.com/114.114.114.114
 server=/zhjxwh.com/114.114.114.114
 server=/zhjypco.com/114.114.114.114
 server=/zhk.me/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -104890,6 +104890,7 @@ server=/zrbx.com/114.114.114.114
 server=/zrcaifu.com/114.114.114.114
 server=/zrcbank.com/114.114.114.114
 server=/zrfan.com/114.114.114.114
+server=/zrfe.com/114.114.114.114
 server=/zrfilm.com/114.114.114.114
 server=/zrhsh.com/114.114.114.114
 server=/zring.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -101656,6 +101656,7 @@ server=/zdlink.com/114.114.114.114
 server=/zdlpk.net/114.114.114.114
 server=/zdm.net/114.114.114.114
 server=/zdmimg.com/114.114.114.114
+server=/zdmq.com/114.114.114.114
 server=/zdmq88.com/114.114.114.114
 server=/zdmr.net/114.114.114.114
 server=/zdnph.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -95981,6 +95981,7 @@ server=/xuprinter.com/114.114.114.114
 server=/xupu.name/114.114.114.114
 server=/xupu120.com/114.114.114.114
 server=/xupupifu.com/114.114.114.114
+server=/xupupower.com/114.114.114.114
 server=/xuqyfw.com/114.114.114.114
 server=/xurong.xyz/114.114.114.114
 server=/xuruowei.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -19941,6 +19941,7 @@ server=/china-sz.com/114.114.114.114
 server=/china-thk.com/114.114.114.114
 server=/china-tin.com/114.114.114.114
 server=/china-tje.com/114.114.114.114
+server=/china-tongyu.com/114.114.114.114
 server=/china-topplus.com/114.114.114.114
 server=/china-tops.com/114.114.114.114
 server=/china-touch.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -102289,6 +102289,7 @@ server=/zhanuan.com/114.114.114.114
 server=/zhanxingfang.com/114.114.114.114
 server=/zhanyaxi.com/114.114.114.114
 server=/zhanyouyun.com/114.114.114.114
+server=/zhanyugroup.com/114.114.114.114
 server=/zhanzhanbao.com/114.114.114.114
 server=/zhanzhang.net/114.114.114.114
 server=/zhanzhangb.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -104188,6 +104188,7 @@ server=/zjnbxzc.com/114.114.114.114
 server=/zjndjs.com/114.114.114.114
 server=/zjnrcb.com/114.114.114.114
 server=/zjnrg.com/114.114.114.114
+server=/zjnthkg.com/114.114.114.114
 server=/zjolcdn.com/114.114.114.114
 server=/zjoldns.com/114.114.114.114
 server=/zjorient.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -96740,6 +96740,7 @@ server=/yangyi09.com/114.114.114.114
 server=/yangyi13.com/114.114.114.114
 server=/yangyi19.com/114.114.114.114
 server=/yangyingming.com/114.114.114.114
+server=/yangyivacuum.com/114.114.114.114
 server=/yangyk.com/114.114.114.114
 server=/yangyongquan.com/114.114.114.114
 server=/yangyq.net/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -20682,6 +20682,7 @@ server=/chinaxzrc.com/114.114.114.114
 server=/chinayadea.com/114.114.114.114
 server=/chinayanghe.com/114.114.114.114
 server=/chinayanming.com/114.114.114.114
+server=/chinayaojiang.com/114.114.114.114
 server=/chinayarn.com/114.114.114.114
 server=/chinaybx.com/114.114.114.114
 server=/chinaygj.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -104106,6 +104106,7 @@ server=/zjjrh.com/114.114.114.114
 server=/zjjrtv.com/114.114.114.114
 server=/zjjsbank.com/114.114.114.114
 server=/zjjsit.com/114.114.114.114
+server=/zjjstzhb.com/114.114.114.114
 server=/zjjtgc.com/114.114.114.114
 server=/zjjubao.com/114.114.114.114
 server=/zjjudong.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -96630,6 +96630,7 @@ server=/yanfengauto.com/114.114.114.114
 server=/yanfukun.com/114.114.114.114
 server=/yang99.fun/114.114.114.114
 server=/yangbentong.com/114.114.114.114
+server=/yangchanji.com/114.114.114.114
 server=/yangchenglianhe.com/114.114.114.114
 server=/yangcheyongche.com/114.114.114.114
 server=/yangchunjian.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -49837,6 +49837,7 @@ server=/jhcb.net/114.114.114.114
 server=/jhcfz.com/114.114.114.114
 server=/jhcheku.com/114.114.114.114
 server=/jhcms.com/114.114.114.114
+server=/jhconba.com/114.114.114.114
 server=/jhctbank.com/114.114.114.114
 server=/jhddsz.com/114.114.114.114
 server=/jhdmro.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -77105,6 +77105,7 @@ server=/shimonote.com/114.114.114.114
 server=/shimonote.net/114.114.114.114
 server=/shimotx.com/114.114.114.114
 server=/shimowendang.com/114.114.114.114
+server=/shindaichem.com/114.114.114.114
 server=/shine-ic.com/114.114.114.114
 server=/shinechina.com/114.114.114.114
 server=/shinefeel.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -22488,6 +22488,7 @@ server=/cnjccrusher.com/114.114.114.114
 server=/cnjecc.com/114.114.114.114
 server=/cnjffb.com/114.114.114.114
 server=/cnjfsilk.com/114.114.114.114
+server=/cnjgtec.com/114.114.114.114
 server=/cnjiajun.com/114.114.114.114
 server=/cnjiali.com/114.114.114.114
 server=/cnjingchu.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -26081,6 +26081,7 @@ server=/deshaus.com/114.114.114.114
 server=/desheng-edu.com/114.114.114.114
 server=/desheng.net/114.114.114.114
 server=/deshenghonglan.com/114.114.114.114
+server=/deshengzj.com/114.114.114.114
 server=/deshicheng.com/114.114.114.114
 server=/design-engine.org/114.114.114.114
 server=/design.citic/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -73183,6 +73183,7 @@ server=/rendoc.com/114.114.114.114
 server=/renead.com/114.114.114.114
 server=/renegade-project.org/114.114.114.114
 server=/renergy-me.com/114.114.114.114
+server=/renew-cn.com/114.114.114.114
 server=/renfei.net/114.114.114.114
 server=/renfutm.com/114.114.114.114
 server=/renguokeji.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -66886,6 +66886,7 @@ server=/odaily.news/114.114.114.114
 server=/odalong.com/114.114.114.114
 server=/odao.com/114.114.114.114
 server=/oddyqw.com/114.114.114.114
+server=/odeasports.com/114.114.114.114
 server=/odict.net/114.114.114.114
 server=/odinichina.com/114.114.114.114
 server=/odinjc.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -103834,6 +103834,7 @@ server=/zizizizizi.com/114.114.114.114
 server=/zizzs.com/114.114.114.114
 server=/zj-art.com/114.114.114.114
 server=/zj-echo.com/114.114.114.114
+server=/zj-equation.com/114.114.114.114
 server=/zj-fhzx.com/114.114.114.114
 server=/zj-gold.com/114.114.114.114
 server=/zj-guojun.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -104297,6 +104297,7 @@ server=/zjyingcai.com/114.114.114.114
 server=/zjyinzuo.com/114.114.114.114
 server=/zjyiot.com/114.114.114.114
 server=/zjyiyuan.com/114.114.114.114
+server=/zjyonder.com/114.114.114.114
 server=/zjyoutian.com/114.114.114.114
 server=/zjyq.cc/114.114.114.114
 server=/zjystec.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -103121,6 +103121,7 @@ server=/zhongniu.com/114.114.114.114
 server=/zhongnongjimu.com/114.114.114.114
 server=/zhongp.com/114.114.114.114
 server=/zhongpaiwang.com/114.114.114.114
+server=/zhongping.com/114.114.114.114
 server=/zhongpingcapital.com/114.114.114.114
 server=/zhongpujiancai.com/114.114.114.114
 server=/zhongqijiye.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -104202,6 +104202,7 @@ server=/zjriji.com/114.114.114.114
 server=/zjrob.com/114.114.114.114
 server=/zjrongli.com/114.114.114.114
 server=/zjrq.com/114.114.114.114
+server=/zjrqchina.com/114.114.114.114
 server=/zjrtv.vip/114.114.114.114
 server=/zjrugao.com/114.114.114.114
 server=/zjrunqiang.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -102429,6 +102429,7 @@ server=/zheishui.com/114.114.114.114
 server=/zheiyu.com/114.114.114.114
 server=/zhejiangcheng.com/114.114.114.114
 server=/zhejiangfc1998.com/114.114.114.114
+server=/zhejianghanpu.com/114.114.114.114
 server=/zhejianglab.com/114.114.114.114
 server=/zhejiangliming.com/114.114.114.114
 server=/zhejianglong.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -22305,6 +22305,7 @@ server=/cndss.net/114.114.114.114
 server=/cndtour.com/114.114.114.114
 server=/cndw.com/114.114.114.114
 server=/cndy.org/114.114.114.114
+server=/cndzh.com/114.114.114.114
 server=/cndzq.com/114.114.114.114
 server=/cndzys.com/114.114.114.114
 server=/cne-motor.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -54169,6 +54169,7 @@ server=/ken.io/114.114.114.114
 server=/kename.com/114.114.114.114
 server=/kendingde.com/114.114.114.114
 server=/kendryte.com/114.114.114.114
+server=/keneng.org/114.114.114.114
 server=/kenflo.com/114.114.114.114
 server=/kenfor.com/114.114.114.114
 server=/kengatoki.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -50826,6 +50826,7 @@ server=/jingytech.com/114.114.114.114
 server=/jingyu.com/114.114.114.114
 server=/jingyuan.com/114.114.114.114
 server=/jingyuelaw.com/114.114.114.114
+server=/jingyuetang.com/114.114.114.114
 server=/jingyunos.com/114.114.114.114
 server=/jingyuweike.com/114.114.114.114
 server=/jingyuxiaoban.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -19622,6 +19622,7 @@ server=/chenlianfu.com/114.114.114.114
 server=/chenliangroup.com/114.114.114.114
 server=/chenlinux.com/114.114.114.114
 server=/chenlinzuwu.com/114.114.114.114
+server=/chenlong.com/114.114.114.114
 server=/chenmomo.com/114.114.114.114
 server=/chenmozz.cc/114.114.114.114
 server=/chennianyoupin.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -50876,6 +50876,7 @@ server=/jinku.com/114.114.114.114
 server=/jinkunlaw.com/114.114.114.114
 server=/jinlaiba.com/114.114.114.114
 server=/jinlaijinwang.com/114.114.114.114
+server=/jinlangbo.com/114.114.114.114
 server=/jinleijx.com/114.114.114.114
 server=/jinletx.com/114.114.114.114
 server=/jinlianchu.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -51988,6 +51988,7 @@ server=/joyshebao.com/114.114.114.114
 server=/joyslink.com/114.114.114.114
 server=/joyssl.com/114.114.114.114
 server=/joysung.com/114.114.114.114
+server=/joysunsh.com/114.114.114.114
 server=/joytest.org/114.114.114.114
 server=/joytourvip.com/114.114.114.114
 server=/joytrav.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -103955,6 +103955,7 @@ server=/zjcyyy.com/114.114.114.114
 server=/zjdadeyy.com/114.114.114.114
 server=/zjdashi.com/114.114.114.114
 server=/zjdata.net/114.114.114.114
+server=/zjdeju.com/114.114.114.114
 server=/zjdetong.com/114.114.114.114
 server=/zjdianying.com/114.114.114.114
 server=/zjdjc.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -94105,6 +94105,7 @@ server=/xinjuc.com/114.114.114.114
 server=/xinjunshi.net/114.114.114.114
 server=/xinjunshicn.net/114.114.114.114
 server=/xinkaiyuanceps.com/114.114.114.114
+server=/xinke-semi.com/114.114.114.114
 server=/xinkejiaotong.com/114.114.114.114
 server=/xinkuai.com/114.114.114.114
 server=/xinkunshan.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -58430,6 +58430,7 @@ server=/lmjtgs.com/114.114.114.114
 server=/lmjx.net/114.114.114.114
 server=/lmjy.us/114.114.114.114
 server=/lmjzd.com/114.114.114.114
+server=/lmkggf.com/114.114.114.114
 server=/lmlc.com/114.114.114.114
 server=/lmlmvip.com/114.114.114.114
 server=/lmm8.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -104321,6 +104321,7 @@ server=/zjxhbj.com/114.114.114.114
 server=/zjxhgd.com/114.114.114.114
 server=/zjxhxny.com/114.114.114.114
 server=/zjxiangyou.com/114.114.114.114
+server=/zjxindongyang.com/114.114.114.114
 server=/zjxindu.com/114.114.114.114
 server=/zjxinghe.com/114.114.114.114
 server=/zjxinyun.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -103899,6 +103899,7 @@ server=/zjai.xyz/114.114.114.114
 server=/zjaijiagroup.com/114.114.114.114
 server=/zjaikang.com/114.114.114.114
 server=/zjairports.com/114.114.114.114
+server=/zjamp.com/114.114.114.114
 server=/zjanchor.com/114.114.114.114
 server=/zjanyy.com/114.114.114.114
 server=/zjaqxy.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -75065,6 +75065,7 @@ server=/scjhyq.com/114.114.114.114
 server=/scjjdd.com/114.114.114.114
 server=/scjjn.com/114.114.114.114
 server=/scjjrb.com/114.114.114.114
+server=/scjk.com/114.114.114.114
 server=/scjmm.com/114.114.114.114
 server=/scjtfh.xyz/114.114.114.114
 server=/scjty.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -27182,6 +27182,7 @@ server=/dlwmkj.com/114.114.114.114
 server=/dlwx369.com/114.114.114.114
 server=/dlxgjy.com/114.114.114.114
 server=/dlxk.com/114.114.114.114
+server=/dlxmicro.com/114.114.114.114
 server=/dlxww.com/114.114.114.114
 server=/dlyiliang.com/114.114.114.114
 server=/dlyll.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -19970,6 +19970,7 @@ server=/china-yaguang.com/114.114.114.114
 server=/china-yansheng.com/114.114.114.114
 server=/china-yd.com/114.114.114.114
 server=/china-yida.com/114.114.114.114
+server=/china-yinda.com/114.114.114.114
 server=/china-yuli.com/114.114.114.114
 server=/china-yulin.com/114.114.114.114
 server=/china-zbycg.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -105422,6 +105422,7 @@ server=/zxhnzq.com/114.114.114.114
 server=/zxhong.com/114.114.114.114
 server=/zxhospital.com/114.114.114.114
 server=/zxhsd.com/114.114.114.114
+server=/zxhuman.com/114.114.114.114
 server=/zxhwzm.com/114.114.114.114
 server=/zxiaoxiang.com/114.114.114.114
 server=/zxicrm.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -54766,6 +54766,7 @@ server=/kmzx.com/114.114.114.114
 server=/kmzx.org/114.114.114.114
 server=/kn-nanjing.com/114.114.114.114
 server=/kn120.com/114.114.114.114
+server=/knbmotor.com/114.114.114.114
 server=/knewbi.com/114.114.114.114
 server=/knewone.com/114.114.114.114
 server=/knewsmart.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -19864,6 +19864,7 @@ server=/china-hongfei.com/114.114.114.114
 server=/china-hp.com/114.114.114.114
 server=/china-hrg.com/114.114.114.114
 server=/china-huazhou.com/114.114.114.114
+server=/china-hulong.com/114.114.114.114
 server=/china-hxzb.com/114.114.114.114
 server=/china-hzd.com/114.114.114.114
 server=/china-indium.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -104191,6 +104191,7 @@ server=/zjpcedu.com/114.114.114.114
 server=/zjpci.com/114.114.114.114
 server=/zjpec.com/114.114.114.114
 server=/zjphrcb.com/114.114.114.114
+server=/zjpia.net/114.114.114.114
 server=/zjpjmy.com/114.114.114.114
 server=/zjplan.com/114.114.114.114
 server=/zjpoetry.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -33870,6 +33870,7 @@ server=/ganxb2.com/114.114.114.114
 server=/ganxi.com/114.114.114.114
 server=/ganxianw.com/114.114.114.114
 server=/ganxianzhi.win/114.114.114.114
+server=/ganyeah.com/114.114.114.114
 server=/ganyu8.net/114.114.114.114
 server=/ganzhe.com/114.114.114.114
 server=/ganzhishi.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -25193,6 +25193,7 @@ server=/danbagui.com/114.114.114.114
 server=/danbaodan.com/114.114.114.114
 server=/dance365.com/114.114.114.114
 server=/dancf.com/114.114.114.114
+server=/danchuangglobal.com/114.114.114.114
 server=/dancihu.com/114.114.114.114
 server=/dancingcg.com/114.114.114.114
 server=/dancizhan.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -64102,6 +64102,7 @@ server=/nanhua.net/114.114.114.114
 server=/nanhuafunds.com/114.114.114.114
 server=/nanhuangic.com/114.114.114.114
 server=/nanhufund.com/114.114.114.114
+server=/nanhujianshe.com/114.114.114.114
 server=/nanhuwang.com/114.114.114.114
 server=/nanjet.com/114.114.114.114
 server=/nanjing-pharma.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -11341,6 +11341,7 @@ server=/ansgo.com/114.114.114.114
 server=/anshahouse.com/114.114.114.114
 server=/anshibuff.com/114.114.114.114
 server=/anshiduo.com/114.114.114.114
+server=/anshinko.com/114.114.114.114
 server=/anshunfiber.com/114.114.114.114
 server=/anshunholdinggroup.com/114.114.114.114
 server=/anshuntech.ltd/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -104010,6 +104010,7 @@ server=/zjharbor.com/114.114.114.114
 server=/zjhbdlkj.com/114.114.114.114
 server=/zjhby.com/114.114.114.114
 server=/zjhcbank.com/114.114.114.114
+server=/zjhcly.com/114.114.114.114
 server=/zjhdchem.com/114.114.114.114
 server=/zjhdcs.com/114.114.114.114
 server=/zjhejiang.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -20315,6 +20315,7 @@ server=/chinajcz.com/114.114.114.114
 server=/chinajeweler.com/114.114.114.114
 server=/chinajienuo.com/114.114.114.114
 server=/chinajincity.com/114.114.114.114
+server=/chinajinguo.com/114.114.114.114
 server=/chinajinlong.com/114.114.114.114
 server=/chinajinzhan.com/114.114.114.114
 server=/chinajinzhou.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -104344,6 +104344,7 @@ server=/zjzhenyou.com/114.114.114.114
 server=/zjzhitan.com/114.114.114.114
 server=/zjzhonglan.com/114.114.114.114
 server=/zjzhongtian.com/114.114.114.114
+server=/zjzj.net/114.114.114.114
 server=/zjzj.org/114.114.114.114
 server=/zjzjhotel.com/114.114.114.114
 server=/zjzjjx.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -50879,6 +50879,7 @@ server=/jinkunlaw.com/114.114.114.114
 server=/jinlaiba.com/114.114.114.114
 server=/jinlaijinwang.com/114.114.114.114
 server=/jinlangbo.com/114.114.114.114
+server=/jinlanzuan.com/114.114.114.114
 server=/jinleijx.com/114.114.114.114
 server=/jinletx.com/114.114.114.114
 server=/jinlianchu.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -71466,6 +71466,7 @@ server=/qlippie.com/114.114.114.114
 server=/qlivecdn.com/114.114.114.114
 server=/qll-times.com/114.114.114.114
 server=/qlmoney.com/114.114.114.114
+server=/qlnonwoven.com/114.114.114.114
 server=/qlotc.net/114.114.114.114
 server=/qlrc.com/114.114.114.114
 server=/qls.fun/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -54477,6 +54477,7 @@ server=/kinqee.com/114.114.114.114
 server=/kinsec.com/114.114.114.114
 server=/kinte-ind.com/114.114.114.114
 server=/kintiger.com/114.114.114.114
+server=/kintn.com/114.114.114.114
 server=/kintowe.com/114.114.114.114
 server=/kinval.com/114.114.114.114
 server=/kinzhan.com/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -23367,6 +23367,7 @@ server=/cosplay8.com/114.114.114.114
 server=/cosplayla.com/114.114.114.114
 server=/cosyjoy.com/114.114.114.114
 server=/cosz.com/114.114.114.114
+server=/cotek-robotics.com/114.114.114.114
 server=/cotong.com/114.114.114.114
 server=/cotticoffee.com/114.114.114.114
 server=/cotv.tv/114.114.114.114

--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -101632,6 +101632,7 @@ server=/zdnscloud.com/114.114.114.114
 server=/zdnscloud.info/114.114.114.114
 server=/zdnscloud.net/114.114.114.114
 server=/zdomo.com/114.114.114.114
+server=/zdong.net/114.114.114.114
 server=/zdpower.com/114.114.114.114
 server=/zdrcw.com/114.114.114.114
 server=/zds22.com/114.114.114.114


### PR DESCRIPTION
1. Add domains
A total of 4,800+ domain names have been added, and the NS servers of all domains have been confirmed to be located in China mainland  through GEOIP database detection.
I have done multiple checks to ensure there are no duplicate or incorrectly formatted domains.