### PR TITLE
[New] wellswam.com

### DIFF
--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -96868,6 +96868,7 @@ server=/wells-shipping.com/114.114.114.114
 server=/wellselectronic.com/114.114.114.114
 server=/wellsepoxy.com/114.114.114.114
 server=/wellsoon.com/114.114.114.114
+server=/wellswam.com/114.114.114.114
 server=/welltonhotel.com/114.114.114.114
 server=/wellwhales.com/114.114.114.114
 server=/welove520.com/114.114.114.114


### PR DESCRIPTION
`wellswam.com` 惠柏新材料科技（上海）股份有限公司 
example: `oa.wellswam.com` for domestic and International access