### PR TITLE
accelerated-domains: remove accountboy.com

### DIFF
--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -10168,7 +10168,6 @@ server=/account-api.dji.com/114.114.114.114
 server=/account.djicdn.com/114.114.114.114
 server=/account.htcvive.com/114.114.114.114
 server=/account.uds-sit.lenovo.com/114.114.114.114
-server=/accountboy.com/114.114.114.114
 server=/accr.cc/114.114.114.114
 server=/accsh.org/114.114.114.114
 server=/acctdns.net/114.114.114.114


### PR DESCRIPTION
Domain:
accountboy.com

Expected behavior:
Traffic to accountboy.com and its subdomains should go through proxy.

Reason:
The domain is unreachable / unstable from mainland China without proxy, but works through proxy.