### PR TITLE
use ruby built-in File#flock instead of filelock gem

### DIFF
--- a/autoupdater.rb
+++ b/autoupdater.rb
@@ -1,6 +1,5 @@
 #!/usr/bin/ruby
 require 'concurrent'
-require 'filelock'
 require 'set'
 require_relative 'verify'
 
@@ -39,7 +38,8 @@ ARGF.each do |domain|
         tested << domain
 
         if v.check_domain_verbose(domain, enable_cdnlist: false, show_green: true)
-            Filelock '.git.lock' do
+            File.open('.git.lock', File::RDWR | File::CREAT) do |lock|
+                lock.flock(File::LOCK_EX)
                 puts `./updater.rb -a #{domain}`
                 puts `git commit -S -am "accelerated-domains: add #{domain}"` if $?.success?
                 puts `./update-local` if $?.success?


### PR DESCRIPTION
使用 Ruby 内置的 File#flock 替代 filelock gem。filelock 打包的发行版太少了（ https://repology.org/project/ruby%3Afilelock/versions ），Debian、Gentoo、Alpine 都没有这个包。
删除 filelock 以后，这个项目里边的所有 ruby 依赖都可以用发行版的包管理器管理了