### PR TITLE
Add made-in-china.com (Focus Technology domestic B2B site)

### DIFF
--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -111629,3 +111629,4 @@ server=/zzzyy.com/114.114.114.114
 server=/zzzyyy.com/114.114.114.114
 server=/zzzzaaaa.com/114.114.114.114
 server=/zzzzzz.me/114.114.114.114
+server=/made-in-china.com/114.114.114.114


### PR DESCRIPTION
Add made-in-china.com, operated by Focus Technology Co., Ltd., a domestic listed company in China.
This is a domestic B2B foreign trade platform. Domestic DNS resolves to mainland China IP, which complies with the repo inclusion rules.