### PR TITLE
accelerated-domains: add yzsgo.com

### DIFF
--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -106779,6 +106779,7 @@ server=/yzs.com/114.114.114.114
 server=/yzs.io/114.114.114.114
 server=/yzsbh.com/114.114.114.114
 server=/yzsfuer.com/114.114.114.114
+server=/yzsgo.com/114.114.114.114
 server=/yzshkjxx.com/114.114.114.114
 server=/yzshyzz.com/114.114.114.114
 server=/yzsljz.com/114.114.114.114


### PR DESCRIPTION
NS servers are located in mainland China (Alibaba Cloud / hichina):

```
$ dig +short NS yzsgo.com
dns29.hichina.com.
dns30.hichina.com.

$ dig +short yzsgo.com @223.5.5.5
39.105.74.236   # Alibaba Cloud Beijing
```

ICP licence: 粤ICP备2026075154号-1 (linked in the footer of https://www.yzsgo.com). All service subdomains (www / app / auth / api) resolve to the same mainland origin.