### PR TITLE
accelerated-domains: add api.blipsandchitz.me

### DIFF
--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -12575,6 +12575,7 @@ server=/api-forwards.com/114.114.114.114
 server=/api-m.com/114.114.114.114
 server=/api-vod-qcloud.com/114.114.114.114
 server=/api.anythinktech.com/114.114.114.114
+server=/api.blipsandchitz.me/114.114.114.114
 server=/api.cnno1.uds.lenovo.com/114.114.114.114
 server=/api.djiservice.org/114.114.114.114
 server=/api.euwe1.uds.lenovo.com/114.114.114.114


### PR DESCRIPTION
## Summary

Add `api.blipsandchitz.me` to `accelerated-domains.china.conf`.

This is the production API endpoint used by Hover Translate---a new quick translation tool for Mac desktops. Feel free to reach out for a trial if you’re interested — everyone who’s tried it loves it!

## DNS and network evidence

AliDNS, Google Public DNS, and Cloudflare DNS return the same records (verified 2026-07-16):

```text
api.blipsandchitz.me.
  CNAME alb-o3q3o6lo8fbwaqbjcf.cn-beijing.alb.aliyuncsslb.com.
  A     8.147.117.74
  A     39.107.228.174
```

The CNAME is an Alibaba Cloud Application Load Balancer in Beijing. APNIC identifies `8.128.0.0/11` as `ALICLOUD` with country `CN`, and `39.96.0.0 - 39.108.255.255` as `ALISOFT` with country `CN`.

Only `api.blipsandchitz.me` is included. The apex domain and `www` currently use Netlify and are intentionally excluded.
