### PR TITLE
accelerated-domains: add lubiao.wiki

### DIFF
--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -62619,6 +62619,7 @@ server=/lubanu.com/114.114.114.114
 server=/lubaocar.com/114.114.114.114
 server=/lubeichem.com/114.114.114.114
 server=/lubiao.com/114.114.114.114
+server=/lubiao.wiki/114.114.114.114
 server=/lubotv.com/114.114.114.114
 server=/luboyun.com/114.114.114.114
 server=/luchengas.com/114.114.114.114


### PR DESCRIPTION
## Summary

Add `lubiao.wiki` to `accelerated-domains.china.conf`.

## Eligibility

- The domain's authoritative nameservers are operated by DNSPod and resolve to mainland China nameserver addresses.
- AliDNS `223.5.5.5`, DNSPod `119.29.29.29`, Google DNS `8.8.8.8`, and Cloudflare DNS `1.1.1.1` return Tencent Cloud CDN addresses in mainland China.
- The site uses Tencent Cloud CDN with a mainland China origin and has an ICP filing: `豫ICP备2024043594号-2`.
- Adding the parent domain also covers `www.lubiao.wiki` and `img.lubiao.wiki`, so no subdomain entries are needed.

## Validation

- `git diff --check`
- `bundle exec sus` using Ruby 3.0 in a clean Linux container: 2 tests and 5 assertions passed
