### PR TITLE
Add missing Apple China GeoServices domain

### DIFF
--- a/apple.china.conf
+++ b/apple.china.conf
@@ -64,6 +64,7 @@ server=/gsp4-cn.ls.apple.com.edgekey.net.globalredir.akadns.net/114.114.114.114
 server=/gsp4-cn.ls.apple.com/114.114.114.114
 server=/gsp5-cn.ls.apple.com/114.114.114.114
 server=/gsp85-cn-ssl.ls.apple.com/114.114.114.114
+server=/gspe11-2-cn-ssl.ls.apple.com/114.114.114.114
 server=/gspe19-2-cn-ssl.ls-apple.com.akadns.net/114.114.114.114
 server=/gspe19-2-cn-ssl.ls.apple.com/114.114.114.114
 server=/gspe19-cn-ssl.ls.apple.com/114.114.114.114


### PR DESCRIPTION
This PR adds a missing Apple China GeoServices domain to apple.china.conf.

Added entry:

server=/gspe11-2-cn-ssl.ls.apple.com/114.114.114.114

Reason:

gspe11-2-cn-ssl.ls.apple.com is used by Apple Maps / GeoServices, including satellite map data requests.

DNS evidence:

@114.114.114.114:
223.109.127.193

@223.5.5.5:
CNAME to w.alikunlun.com, then mainland China CDN IPs.

@119.29.29.29:
CNAME to ks-cdn.com / ksyuncdn.com, then 223.109.127.193.

I also checked that there is no broader ls.apple.com parent rule in apple.china.conf, so this is not a duplicate subdomain entry.