### PR TITLE
accelerated-domains: add openbitfun.com

### DIFF
--- a/accelerated-domains.china.conf
+++ b/accelerated-domains.china.conf
@@ -70434,6 +70434,7 @@ server=/openasic.org/114.114.114.114
 server=/openatom.club/114.114.114.114
 server=/openbayes.com/114.114.114.114
 server=/openbcs.com/114.114.114.114
+server=/openbitfun.com/114.114.114.114
 server=/opencas.org/114.114.114.114
 server=/opencitybrain.org/114.114.114.114
 server=/opencloudgpt.online/114.114.114.114


### PR DESCRIPTION
## Summary

Add `openbitfun.com` to `accelerated-domains.china.conf`.

The parent-domain rule covers the website and all service subdomains, including `release.openbitfun.com` and `market.openbitfun.com`.

## Eligibility

- Authoritative nameservers are Alibaba Cloud / HiChina:
  - `dns9.hichina.com`
  - `dns10.hichina.com`
- This repository already includes `.hichina.com` in `ns-whitelist.txt`, so the domain meets the project's NS eligibility rule.
- The website and release endpoint are served through Huawei Cloud WAF (`*.vip1.huaweicloudwaf.com`).

## Motivation

BitFun publishes its official release mirror under `openbitfun.com/release/`. Mainland users often use rule-based proxy clients; without a parent-domain domestic/direct classification, the mirror can be sent through a VPN and become slower than a direct connection.

Downstream projects also consume this list for domestic/direct routing, so adding the parent domain avoids per-subdomain maintenance.

## Validation

- Entry is in lexical order.
- `git diff --check` passes.
- The repository's full Ruby test command could not be run locally because the macOS system Ruby 2.6 trust store rejected rubygems.org's certificate; upstream CI remains the authoritative test.
